### PR TITLE
[Reviewer: Andy] Don't require eth0 - don't specify it in iptables.rules

### DIFF
--- a/iptables.rules
+++ b/iptables.rules
@@ -3,7 +3,7 @@
 :PREROUTING ACCEPT [12:552]
 :POSTROUTING ACCEPT [47:3088]
 :OUTPUT ACCEPT [47:3088]
--A PREROUTING -i eth0 -p tcp -m tcp --dport 80 -j REDIRECT --to-ports 8888 
--A PREROUTING -i eth0 -p tcp -m tcp --dport 443 -j REDIRECT --to-ports 8443 
+-A PREROUTING -p tcp -m tcp --dport 80 -j REDIRECT --to-ports 8888 
+-A PREROUTING -p tcp -m tcp --dport 443 -j REDIRECT --to-ports 8443 
 COMMIT
 # Completed on Thu May  3 17:31:32 2012


### PR DESCRIPTION
Andy, please can you review this fix?  If there are multiple Ethernet interfaces, our iptables-based port redirection didn't work because it explicitly specified eth0.  This fix is just to remove that.  I've successfully tested this live (obviously, there's no UT).  You should have just seen a similar fix for ellis.
