### PR TITLE
[Reviewer: Andy] Clean install output

### DIFF
--- a/homer.root/etc/clearwater/scripts/homer
+++ b/homer.root/etc/clearwater/scripts/homer
@@ -2,5 +2,12 @@
 . /etc/clearwater/config
 sed -e 's/^SIP_DIGEST_REALM = .*$/SIP_DIGEST_REALM = "'$home_domain'"/g
         s/^CASS_HOST = .*$/CASS_HOST = "'localhost'"/g' </usr/share/clearwater/homer/src/metaswitch/crest/local_settings.py >/tmp/local_settings.py.$$
-cp /tmp/local_settings.py.$$ /usr/share/clearwater/homer/src/metaswitch/crest/local_settings.py
-mv /tmp/local_settings.py.$$ /usr/share/clearwater/homer/env/lib/python2.7/site-packages/crest-0.1-py2.7.egg/metaswitch/crest/local_settings.py
+for dst in /usr/share/clearwater/homer/src/metaswitch/crest/local_settings.py \
+           /usr/share/clearwater/homer/env/lib/python2.7/site-packages/crest-0.1-py2.7.egg/metaswitch/crest/local_settings.py
+do
+  if [ -f $dst ]
+  then
+    cp /tmp/local_settings.py.$$ $dst
+  fi
+done
+rm /tmp/local_settings.py.$$

--- a/homestead.root/etc/clearwater/scripts/homestead
+++ b/homestead.root/etc/clearwater/scripts/homestead
@@ -2,5 +2,12 @@
 . /etc/clearwater/config
 sed -e 's/^SIP_DIGEST_REALM = .*$/SIP_DIGEST_REALM = "'$home_domain'"/g
         s/^CASS_HOST = .*$/CASS_HOST = "'localhost'"/g' </usr/share/clearwater/homestead/src/metaswitch/crest/local_settings.py >/tmp/local_settings.py.$$
-cp /tmp/local_settings.py.$$ /usr/share/clearwater/homestead/src/metaswitch/crest/local_settings.py
-mv /tmp/local_settings.py.$$ /usr/share/clearwater/homestead/env/lib/python2.7/site-packages/crest-0.1-py2.7.egg/metaswitch/crest/local_settings.py
+for dst in /usr/share/clearwater/homestead/src/metaswitch/crest/local_settings.py \
+           /usr/share/clearwater/homestead/env/lib/python2.7/site-packages/crest-0.1-py2.7.egg/metaswitch/crest/local_settings.py
+do
+  if [ -f $dst ]
+  then
+    cp /tmp/local_settings.py.$$ $dst
+  fi
+done
+rm /tmp/local_settings.py.$$


### PR DESCRIPTION
Andy, please can you review my fix to get a clean install of crest?  Previously, we sometimes got the following (benign) error.

```
Setting up clearwater-infrastructure (1.0-130507.080417) ...
mv: cannot move `/tmp/local_settings.py.9390' to `/usr/share/clearwater/homer/env/lib/python2.7/site-packages/crest-0.1-py2.7.egg/metaswitch/crest/local_settings.py': No such file or directory
```

This was because we hadn't yet installed homer, and so hadn't unpacked its egg, so the directory didn't exist.  The key point of my fix is to check that files (and hence their parent directories) exist before copying - if they don't, it's safe not to do the copy, because it will get fixed up later anyway.  The rest of the change (moving to the for loop) is just to make the code tidier.
