### PR TITLE
Reviewer Felix: Do database accesses in parallel where possible

### DIFF
--- a/src/metaswitch/crest/test/api/homestead/associateduris.py
+++ b/src/metaswitch/crest/test/api/homestead/associateduris.py
@@ -39,7 +39,7 @@ import httplib
 import mock
 import unittest
 
-from mock import ANY, call
+from mock import ANY, call, DEFAULT
 from cyclone.web import HTTPError
 from telephus.cassandra.ttypes import NotFoundException, Column, ColumnOrSuperColumn
 from twisted.internet import defer
@@ -148,42 +148,33 @@ class TestAssociatedPublicHandler(unittest.TestCase):
 
         rv = self.mock_cass.get_slice.return_value
         self.mock_cass.reset_mock()
-        self.mock_cass.get_slice.return_value = defer.Deferred()
-        rv.callback([])
 
-        # 2x get-slice to check for limits
+        # prepare for the 2x get-slice calls to check for limits
+        def side_effect_slice (column_family, key):
+            if (column_family == config.PUBLIC_IDS_TABLE and key == 'priv'):
+                return []
+            elif (column_family == config.PRIVATE_IDS_TABLE and key == 'sip:pub'):
+                return []
+            else:
+                raise Exception('FAIL')
 
-        self.mock_cass.get_slice.assert_called_once_with(column_family=config.PUBLIC_IDS_TABLE,
-                                                         key='priv')
-
-        rv = self.mock_cass.get_slice.return_value
-        self.mock_cass.reset_mock()
-        self.mock_cass.get_slice.return_value = defer.Deferred()
-        rv.callback([])
-
-        self.mock_cass.get_slice.assert_called_once_with(column_family=config.PRIVATE_IDS_TABLE,
-                                                         key='sip:pub')
-
-        rv = self.mock_cass.get_slice.return_value
-        self.mock_cass.reset_mock()
+        self.mock_cass.get_slice.side_effect = side_effect_slice
         self.mock_cass.insert.return_value = defer.Deferred()
-        rv.callback([])
 
-        # 2 x insert
+        rv.callback([])  # The callback on the original get_slice
+                         # This will trigger the 2 get_slices, and then
+                         # the two inserts
 
-        self.mock_cass.insert.assert_called_once_with(column_family=config.PUBLIC_IDS_TABLE, key='priv', column='sip:pub', value='sip:pub')
-
-        rv = self.mock_cass.insert.return_value
-        self.mock_cass.reset_mock()
-        self.mock_cass.insert.return_value = defer.Deferred()
-        rv.callback(mock.MagicMock())
-
-        self.mock_cass.insert.assert_called_once_with(column_family=config.PRIVATE_IDS_TABLE, key='sip:pub', column='priv', value='priv')
-
-        rv = self.mock_cass.insert.return_value
-        self.mock_cass.reset_mock()
+        # Restore the get_slice mock in in advance of the final call on it.
         self.mock_cass.get_slice.return_value = defer.Deferred()
-        rv.callback(mock.MagicMock())
+        self.mock_cass.get_slice.side_effect = None
+
+        self.mock_cass.insert.assert_has_calls([call(column_family=config.PUBLIC_IDS_TABLE, key='priv', column='sip:pub', value='sip:pub'),
+                                                call(column_family=config.PRIVATE_IDS_TABLE, key='sip:pub', column='priv', value='priv')],
+                                               any_order = True)
+
+        self.mock_cass.reset_mock()
+        self.mock_cass.insert.return_value.callback(mock.MagicMock())
 
         # get_slice public IDs, key=priv to get returned data
         self.mock_cass.get_slice.assert_called_once_with(column_family=config.PUBLIC_IDS_TABLE,
@@ -247,49 +238,42 @@ class TestAssociatedPublicHandler(unittest.TestCase):
 
         rv = self.mock_cass.get_slice.return_value
         self.mock_cass.reset_mock()
-        self.mock_cass.get_slice.return_value = defer.Deferred()
-        rv.callback([])
 
-        # 2x get-slice to check for limits
-        self.mock_cass.get_slice.assert_called_once_with(column_family=config.PUBLIC_IDS_TABLE,
-                                                         key='priv')
+        # Prepare for the 2x get-slice calls to check for limits
+        # return the first call with data, the 2nd without
+        def side_effect_slice (column_family, key):
+            if (column_family == config.PUBLIC_IDS_TABLE and key == 'priv'):
+                return (
+                    [ColumnOrSuperColumn(column=Column(timestamp=1371131096949743,
+                    name='sip:pub', value='sip:pub', ttl=None), counter_super_column=None,
+                    super_column=None, counter_column=None)])
+            elif (column_family == config.PRIVATE_IDS_TABLE and key == 'sip:pub2'):
+                return []
+            else:
+                raise Exception('FAIL')
 
-        result_list = [
-             ColumnOrSuperColumn(column=Column(timestamp=1371131096949743,
-            name='sip:pub', value='sip:pub', ttl=None), counter_super_column=None,
-            super_column=None, counter_column=None)]
-
-        rv = self.mock_cass.get_slice.return_value
-        self.mock_cass.reset_mock()
-        self.mock_cass.get_slice.return_value = defer.Deferred()
-        rv.callback(result_list)
-
-        self.mock_cass.get_slice.assert_called_once_with(column_family=config.PRIVATE_IDS_TABLE,
-                                                         key='sip:pub2')
-
-        rv = self.mock_cass.get_slice.return_value
-        self.mock_cass.reset_mock()
+        self.mock_cass.get_slice.side_effect = side_effect_slice
         self.mock_cass.insert.return_value = defer.Deferred()
-        rv.callback([])
 
-        # 2 x insert
-        self.mock_cass.insert.assert_called_once_with(column_family=config.PUBLIC_IDS_TABLE, key='priv', column='sip:pub2', value='sip:pub2')
+        rv.callback([])  # The callback on the original get_slice
+                         # This will trigger the 2 get_slices, and then
+                         # the two inserts
 
-        rv = self.mock_cass.insert.return_value
-        self.mock_cass.reset_mock()
-        self.mock_cass.insert.return_value = defer.Deferred()
-        rv.callback(mock.MagicMock())
-
-        self.mock_cass.insert.assert_called_once_with(column_family=config.PRIVATE_IDS_TABLE, key='sip:pub2', column='priv', value='priv')
-
-        rv = self.mock_cass.insert.return_value
-        self.mock_cass.reset_mock()
+        # Restore the get_slice mockin in advance of the final call on it.
         self.mock_cass.get_slice.return_value = defer.Deferred()
-        rv.callback(mock.MagicMock())
+        self.mock_cass.get_slice.side_effect = None
+
+        self.mock_cass.insert.assert_has_calls([call(column_family=config.PUBLIC_IDS_TABLE, key='priv', column='sip:pub2', value='sip:pub2'),
+                                                call(column_family=config.PRIVATE_IDS_TABLE, key='sip:pub2', column='priv', value='priv')],
+                                               any_order = True)
+
+        self.mock_cass.reset_mock()
+        self.mock_cass.insert.return_value.callback(mock.MagicMock())
 
         # get_slice public IDs, key=priv to get returned data
         self.mock_cass.get_slice.assert_called_once_with(column_family=config.PUBLIC_IDS_TABLE,
                                                          key='priv')
+
         result_list = [
             ColumnOrSuperColumn(column=Column(timestamp=1371131096949743,
             name='sip:pub', value='sip:pub', ttl=None), counter_super_column=None,
@@ -316,37 +300,37 @@ class TestAssociatedPublicHandler(unittest.TestCase):
                                                          start='sip:pub2',
                                                          finish='sip:pub2')
 
-
         rv = self.mock_cass.get_slice.return_value
         self.mock_cass.reset_mock()
-        self.mock_cass.get_slice.return_value = defer.Deferred()
-        rv.callback([])
 
-        # 2x get-slice to check for limits
-        self.mock_cass.get_slice.assert_called_once_with(column_family=config.PUBLIC_IDS_TABLE,
-                                                          key='priv')
+        # Prepare for the 2x get-slice calls to check for limits
+        def side_effect_slice (column_family, key):
+            if (column_family == config.PUBLIC_IDS_TABLE and key == 'priv'):
+                return (
+                   [ColumnOrSuperColumn(column=Column(timestamp=1371131096949743,
+                    name='sip:pub', value='sip:pub', ttl=None), counter_super_column=None,
+                    super_column=None, counter_column=None),
+                    ColumnOrSuperColumn(column=Column(timestamp=1371131096949743,
+                    name='sip:pub2', value='sip:pub2', ttl=None), counter_super_column=None,
+                    super_column=None, counter_column=None),
+                    ColumnOrSuperColumn(column=Column(timestamp=1371131096949743,
+                    name='sip:pub3', value='sip:pub3', ttl=None), counter_super_column=None,
+                    super_column=None, counter_column=None),
+                    ColumnOrSuperColumn(column=Column(timestamp=1371131096949743,
+                    name='sip:pub4', value='sip:pub4', ttl=None), counter_super_column=None,
+                    super_column=None, counter_column=None),
+                    ColumnOrSuperColumn(column=Column(timestamp=1371131096949743,
+                    name='sip:pub5', value='sip:pub5', ttl=None), counter_super_column=None,
+                    super_column=None, counter_column=None)])
+            elif (column_family == config.PRIVATE_IDS_TABLE and key == 'sip:pub2'):
+                return []
+            else:
+                raise Exception('FAIL')
 
-        result_list = [
-            ColumnOrSuperColumn(column=Column(timestamp=1371131096949743,
-            name='sip:pub', value='sip:pub', ttl=None), counter_super_column=None,
-            super_column=None, counter_column=None),
-            ColumnOrSuperColumn(column=Column(timestamp=1371131096949743,
-            name='sip:pub2', value='sip:pub2', ttl=None), counter_super_column=None,
-            super_column=None, counter_column=None),
-            ColumnOrSuperColumn(column=Column(timestamp=1371131096949743,
-            name='sip:pub3', value='sip:pub3', ttl=None), counter_super_column=None,
-            super_column=None, counter_column=None),
-            ColumnOrSuperColumn(column=Column(timestamp=1371131096949743,
-            name='sip:pub4', value='sip:pub4', ttl=None), counter_super_column=None,
-            super_column=None, counter_column=None),
-            ColumnOrSuperColumn(column=Column(timestamp=1371131096949743,
-            name='sip:pub5', value='sip:pub5', ttl=None), counter_super_column=None,
-            super_column=None, counter_column=None)]
+        self.mock_cass.get_slice.side_effect = side_effect_slice
 
-        rv = self.mock_cass.get_slice.return_value
-        self.mock_cass.reset_mock()
-        self.mock_cass.insert.return_value = defer.Deferred()
-        rv.callback(result_list)
+        rv.callback([])  # The callback on the original get_slice
+                         # This will trigger the 2 get_slices
 
         post_errback = mock.MagicMock()
         post_deferred.addErrback(post_errback)
@@ -511,42 +495,38 @@ class TestAssociatedPrivateHandler(unittest.TestCase):
 
         rv = self.mock_cass.get_slice.return_value
         self.mock_cass.reset_mock()
-        self.mock_cass.get_slice.return_value = defer.Deferred()
-        rv.callback([])
 
-        # 2x get-slice to check for limits
+        # Prepare for 2x get-slice calls to check for limits
+        def side_effect_slice (column_family, key):
+            if (column_family == config.PUBLIC_IDS_TABLE and key == 'priv'):
+                return []
+            elif (column_family == config.PRIVATE_IDS_TABLE and key == 'sip:pub'):
+                return []
+            else:
+                raise Exception('FAIL')
 
-        self.mock_cass.get_slice.assert_called_once_with(column_family=config.PUBLIC_IDS_TABLE,
-                                                          key='priv')
-
-        rv = self.mock_cass.get_slice.return_value
-        self.mock_cass.reset_mock()
-        self.mock_cass.get_slice.return_value = defer.Deferred()
-        rv.callback([])
-
-        self.mock_cass.get_slice.assert_called_once_with(column_family=config.PRIVATE_IDS_TABLE,
-                                                         key='sip:pub')
-        rv = self.mock_cass.get_slice.return_value
-        self.mock_cass.reset_mock()
+        self.mock_cass.get_slice.side_effect = side_effect_slice
         self.mock_cass.insert.return_value = defer.Deferred()
-        rv.callback([])
 
-        # 2 x insert
-        self.mock_cass.insert.assert_called_once_with(column_family=config.PUBLIC_IDS_TABLE, key='priv', column='sip:pub', value='sip:pub')
-        rv = self.mock_cass.insert.return_value
-        self.mock_cass.reset_mock()
-        self.mock_cass.insert.return_value = defer.Deferred()
-        rv.callback(mock.MagicMock())
+        rv.callback([])  # The callback on the original get_slice
+                         # This will trigger the 2 get_slices, and then
+                         # the two inserts
 
-        self.mock_cass.insert.assert_called_once_with(column_family=config.PRIVATE_IDS_TABLE, key='sip:pub', column='priv', value='priv')
-        rv = self.mock_cass.insert.return_value
-        self.mock_cass.reset_mock()
+        # Restore the get_slice mock in in advance of the final call on it.
         self.mock_cass.get_slice.return_value = defer.Deferred()
-        rv.callback(mock.MagicMock())
+        self.mock_cass.get_slice.side_effect = None
+
+        self.mock_cass.insert.assert_has_calls([call(column_family=config.PUBLIC_IDS_TABLE, key='priv', column='sip:pub', value='sip:pub'),
+                                                call(column_family=config.PRIVATE_IDS_TABLE, key='sip:pub', column='priv', value='priv')],
+                                               any_order = True)
+
+        self.mock_cass.reset_mock()
+        self.mock_cass.insert.return_value.callback(mock.MagicMock())
 
         # get_slice public IDs, key=priv to get returned data
         self.mock_cass.get_slice.assert_called_once_with(column_family=config.PRIVATE_IDS_TABLE,
                                                          key='sip:pub')
+
         result_list = [
              ColumnOrSuperColumn(column=Column(timestamp=1371131096949743,
             name='priv', value='priv', ttl=None), counter_super_column=None,
@@ -573,44 +553,39 @@ class TestAssociatedPrivateHandler(unittest.TestCase):
 
         rv = self.mock_cass.get_slice.return_value
         self.mock_cass.reset_mock()
-        self.mock_cass.get_slice.return_value = defer.Deferred()
-        rv.callback([])
 
-        # 2x get-slice to check for limits
-        self.mock_cass.get_slice.assert_called_once_with(column_family=config.PUBLIC_IDS_TABLE,
-                                                         key='priv')
+        # Prepare for 2x get-slice to check for limits
+        def side_effect_slice (column_family, key):
+            if (column_family == config.PUBLIC_IDS_TABLE and key == 'priv'):
+                return []
+            elif (column_family == config.PRIVATE_IDS_TABLE and key == 'sip:pub'):
+                self.mock_cass.get_slice.return_value = defer.Deferred()
+                return []
+            else:
+                raise Exception('FAIL')
 
-        rv = self.mock_cass.get_slice.return_value
-        self.mock_cass.reset_mock()
-        self.mock_cass.get_slice.return_value = defer.Deferred()
-        rv.callback([])
+        self.mock_cass.get_slice.side_effect = side_effect_slice
 
-        self.mock_cass.get_slice.assert_called_once_with(column_family=config.PRIVATE_IDS_TABLE,
-                                                         key='sip:pub')
-        rv = self.mock_cass.get_slice.return_value
-        self.mock_cass.reset_mock()
-        self.mock_cass.insert.return_value = defer.Deferred()
-        rv.callback([])
+        # Prepare for 2x insert calls, one of which we will throw an exception on
+        def side_effect_insert (column_family, key):
+            if (column_family == config.PUBLIC_IDS_TABLE and key == 'priv' and
+                                   column == 'sip:pub' and value == 'sip:pub'):
+                return mock.MagicMock()
+            elif (column_family == config.PRIVATE_IDS_TABLE and key == 'sip:pub' and
+                                         column == 'priv' and value == 'priv'):
+                # the key point... throw an exception from the database.  Doesn't matter what.
+                raise Exception("fail")
+            else:
+                raise Exception('FAIL')
 
-        # 2 x insert
-        self.mock_cass.insert.assert_called_once_with(column_family=config.PUBLIC_IDS_TABLE, key='priv', column='sip:pub', value='sip:pub')
-        rv = self.mock_cass.insert.return_value
-        self.mock_cass.reset_mock()
-        self.mock_cass.insert.return_value = defer.Deferred()
-        rv.callback(mock.MagicMock())
+        self.mock_cass.insert.side_effect = side_effect_insert
 
-        self.mock_cass.insert.assert_called_once_with(column_family=config.PRIVATE_IDS_TABLE, key='sip:pub', column='priv', value='priv')
+        rv.callback([])  # The callback on the original get_slice
+                         # This will trigger the 2 get_slices, and then
+                         # the two inserts
 
-        rv = self.mock_cass.insert.return_value
-        self.mock_cass.reset_mock()
-        self.mock_cass.remove.return_value = defer.Deferred()
-
-        # the key point... throw an exception from the database.  Doesn't matter what.
-        rv.errback(Exception("fail"))
-
-        # get_slice public IDs, key=priv to get returned data
-        self.mock_cass.remove.assert_called_once_with(column_family=config.PUBLIC_IDS_TABLE,
-                                                         key='priv', column='sip:pub', value='sip:pub')
+        self.mock_cass.remove.assert_has_calls([call(column_family=config.PUBLIC_IDS_TABLE, key='priv', column='sip:pub', value='sip:pub'),
+                                                call(column_family=config.PRIVATE_IDS_TABLE, key='sip:pub', column='priv', value='priv')])
         self.mock_cass.remove.return_value.callback(mock.MagicMock())
 
         self.assertEquals(post_errback.call_args[0][0].getErrorMessage(), 'HTTP 500: Internal Server Error')
@@ -667,34 +642,27 @@ class TestAssociatedPrivateHandler(unittest.TestCase):
         rv = self.mock_cass.get_slice.return_value
         self.mock_cass.reset_mock()
         self.mock_cass.get_slice.return_value = defer.Deferred()
-        rv.callback([])
 
-        # 2x get-slice to check for limits
-        self.mock_cass.get_slice.assert_called_once_with(column_family=config.PUBLIC_IDS_TABLE,
-                                                         key='priv2')
+        # Prepare for 2x get-slice calls to check for limits
 
-        result_list = [
-            ColumnOrSuperColumn(column=Column(timestamp=1371131096949743,
-            name='sip:pub', value='sip:pub', ttl=None), counter_super_column=None,
-            super_column=None, counter_column=None)]
+        def side_effect_slice (column_family, key):
+            if (column_family == config.PUBLIC_IDS_TABLE and key == 'priv2'):
+                return (
+                   [ColumnOrSuperColumn(column=Column(timestamp=1371131096949743,
+                    name='sip:pub', value='sip:pub', ttl=None), counter_super_column=None,
+                    super_column=None, counter_column=None)])
+            elif (column_family == config.PRIVATE_IDS_TABLE and key == 'sip:pub'):
+                return(
+                   [ColumnOrSuperColumn(column=Column(timestamp=1371131096949743,
+                    name='priv', value='priv', ttl=None), counter_super_column=None,
+                    super_column=None, counter_column=None)])
+            else:
+                raise Exception('FAIL')
 
-        rv = self.mock_cass.get_slice.return_value
-        self.mock_cass.reset_mock()
-        self.mock_cass.get_slice.return_value = defer.Deferred()
-        rv.callback(result_list)
+        self.mock_cass.get_slice.side_effect = side_effect_slice
 
-        self.mock_cass.get_slice.assert_called_once_with(column_family=config.PRIVATE_IDS_TABLE,
-                                                          key='sip:pub')
-
-        result_list = [
-            ColumnOrSuperColumn(column=Column(timestamp=1371131096949743,
-            name='priv', value='priv', ttl=None), counter_super_column=None,
-            super_column=None, counter_column=None)]
-
-        rv = self.mock_cass.get_slice.return_value
-        self.mock_cass.reset_mock()
-        self.mock_cass.get_slice.return_value = defer.Deferred()
-        rv.callback(result_list)
+        rv.callback([])  # The callback on the original get_slice
+                         # This will trigger the 2 get_slices
 
         post_errback = mock.MagicMock()
         post_deferred.addErrback(post_errback)


### PR DESCRIPTION
Make the DB accesses go in parallel where possible.  The complexity of the change is almost entirely in the UTs, which are, sadly, less readable as a result.
