### PR TITLE
[Reviewer: Felix] Reinstate incorrectly-removed "unused field": XDM_DEFAULT_SIMSERVS_FILE

### DIFF
--- a/homestead.local_settings/local_settings.py
+++ b/homestead.local_settings/local_settings.py
@@ -38,6 +38,7 @@ LOG_FILE_PREFIX = "homestead"
 CASS_KEYSPACE = "homestead"
 INSTALLED_HANDLERS = ["homestead"]
 HTTP_PORT = 8888
+XDM_DEFAULT_SIMSERVS_FILE = "/usr/share/clearwater/homestead/modules/common/metaswitch/common/default_simservs.xml"
 
 # Debian install will pick this up from /etc/clearwater/config 
 CASS_HOST = "localhost"


### PR DESCRIPTION
Felix, please can you review my fix to bulk provisioning?  The XDM_DEFAULT_SIMSERVS_FILE was incorrectly removed from local_settings.py.  I've reinstated it.  I've live tested.
