### PR TITLE
[Reviewer: Felix] Update bulk provisioning to handle new schema (fixes #30)

### DIFF
--- a/src/metaswitch/crest/tools/sstable_provisioning/ClearwaterBulkProvisioner.java
+++ b/src/metaswitch/crest/tools/sstable_provisioning/ClearwaterBulkProvisioner.java
@@ -108,6 +108,34 @@ public class ClearwaterBulkProvisioner
                 null,
                 64);
 
+        String public_ids_table = "public_ids";
+        File public_ids_directory = new File(keyspace + "/" + public_ids_table);
+        if (!public_ids_directory.exists())
+            public_ids_directory.mkdir();
+
+        SSTableSimpleUnsortedWriter publicIdsWriter = new SSTableSimpleUnsortedWriter(
+                public_ids_directory,
+                new RandomPartitioner(),
+                keyspace,
+                public_ids_table,
+                AsciiType.instance,
+                null,
+                64);
+
+        String private_ids_table = "private_ids";
+        File private_ids_directory = new File(keyspace + "/" + private_ids_table);
+        if (!private_ids_directory.exists())
+            private_ids_directory.mkdir();
+
+        SSTableSimpleUnsortedWriter privateIdsWriter = new SSTableSimpleUnsortedWriter(
+                private_ids_directory,
+                new RandomPartitioner(),
+                keyspace,
+                private_ids_table,
+                AsciiType.instance,
+                null,
+                64);
+
         String ifc_table = "filter_criteria";
         File ifc_directory = new File(keyspace + "/" + ifc_table);
         if (!ifc_directory.exists())
@@ -133,6 +161,10 @@ public class ClearwaterBulkProvisioner
             {
                 digestWriter.newRow(bytes(entry.private_id));
                 digestWriter.addColumn(bytes("digest"), bytes(entry.digest), timestamp);
+                publicIdsWriter.newRow(bytes(entry.private_id));
+                publicIdsWriter.addColumn(bytes(entry.public_id), bytes(entry.public_id), timestamp);
+                privateIdsWriter.newRow(bytes(entry.public_id));
+                privateIdsWriter.addColumn(bytes(entry.private_id), bytes(entry.private_id), timestamp);
                 ifcWriter.newRow(bytes(entry.public_id));
                 ifcWriter.addColumn(bytes("value"), bytes(entry.ifc), timestamp);
             }
@@ -140,6 +172,8 @@ public class ClearwaterBulkProvisioner
         }
         // Don't forget to close!
         digestWriter.close();
+        publicIdsWriter.close();
+        privateIdsWriter.close();
         ifcWriter.close();
         System.exit(0);
     }

--- a/src/metaswitch/crest/tools/sstable_provisioning/README.md
+++ b/src/metaswitch/crest/tools/sstable_provisioning/README.md
@@ -58,4 +58,6 @@ _For homestead:_
 
     . /etc/clearwater/config
     sstableloader -v -d $local_ip homestead/sip_digests
+    sstableloader -v -d $local_ip homestead/public_ids
+    sstableloader -v -d $local_ip homestead/private_ids
     sstableloader -v -d $local_ip homestead/filter_criteria


### PR DESCRIPTION
Felix, please can you review my changes to fix bulk provisioning following last week's schema changes?

I have
-   updated `bulk_create.py` to use `cassandra-cli` and fill in the new `public_ids` and `private_ids` tables
-   updated `ClearwaterBulkProvisioner.java` to fill in the new `public_ids` and `private_ids` tables
-   updated `README.md` to note that you need to call `sstableloader` for the two new tables
-   successfully live tested both bulk-provisioning approaches.
