### PR TITLE
[Reviewer: Andy] Move from using bootstrap.py to easy_install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,13 +45,12 @@ else
 	ARCHFLAGS="-arch i386 -arch x86_64" ./bin/buildout -N
 endif
 
-bin/buildout: $(ENV_DIR)/bin/python bootstrap.py
+bin/buildout: $(ENV_DIR)/bin/python
 	mkdir -p .buildout_downloads/dist
 	cp thrift_download/thrift-0.8.0.tar.gz .buildout_downloads/dist/
-	bash ./bootstrap-wrapper.sh $(ENV_DIR)
-
-bootstrap.py:
-	curl -S -s -O http://python-distribute.org/bootstrap.py
+	$(ENV_DIR)/bin/easy_install zc.buildout
+	$(ENV_DIR)/bin/buildout
+	ln -s $(ENV_DIR)/bin/buildout ./bin/buildout
 
 $(ENV_DIR)/bin/python:
 	virtualenv --no-site-packages --distribute --python=$(PYTHON_BIN) $(ENV_DIR)

--- a/bootstrap-wrapper.sh
+++ b/bootstrap-wrapper.sh
@@ -1,7 +1,0 @@
-#! /bin/bash
-$1/bin/python bootstrap.py
-retval=$?
-if [[ $retval != 0 ]]; then
-  echo -e "\n\nFailed to retrieve some third party Python packages.\nThis is usually caused by http://pypi.python.org being down.\nSee above for full error output.\n"
-fi
-exit $retval


### PR DESCRIPTION
Andy, please can you review my fix to move from using bootstrap to using easy_install directly (bootstrap just installed a new easy_install to use under the covers anyway).  easy_install supports gzip encoding, which means the problem with pypi.org serving gzip-encoded content in response to a request for identity-encoded content goes away.  I've tested this on repo.cw-ngv.com.

A similar change to ellis will follow shortly.
