### PR TITLE
[Reviewer: Andy] Fix issues about missing zc.buildout egg

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,6 @@ bin/buildout: $(ENV_DIR)/bin/python
 	cp thrift_download/thrift-0.8.0.tar.gz .buildout_downloads/dist/
 	$(ENV_DIR)/bin/easy_install zc.buildout
 	$(ENV_DIR)/bin/buildout
-	ln -s $(ENV_DIR)/bin/buildout ./bin/buildout
 
 $(ENV_DIR)/bin/python:
 	virtualenv --no-site-packages --distribute --python=$(PYTHON_BIN) $(ENV_DIR)

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -5,6 +5,7 @@ parts =
   sdp
   pure-sasl
   telephus
+  zc.buildout
   coverage
   python
   twisted
@@ -53,6 +54,11 @@ eggs =
   telephus
   
 # Dependancies
+[zc.buildout]
+recipe = zc.recipe.egg
+eggs =
+  zc.buildout ==2.2.0
+
 [coverage]
 recipe = zc.recipe.egg
 eggs =
@@ -106,6 +112,7 @@ eggs =
   ${sdp:eggs}
   ${pure-sasl:eggs}
   ${telephus:eggs}
+  ${zc.buildout:eggs}
   ${coverage:eggs}
   ${twisted:eggs}
   ${cyclone:eggs}

--- a/debian/homer.install
+++ b/debian/homer.install
@@ -1,4 +1,5 @@
 eggs usr/share/clearwater/homer/
+_env/lib/python2.7/site-packages/zc.buildout-2.2.0-py2.7.egg usr/share/clearwater/homer/eggs/
 setup.py usr/share/clearwater/homer/
 src usr/share/clearwater/homer/
 modules usr/share/clearwater/homer/

--- a/debian/homestead.install
+++ b/debian/homestead.install
@@ -1,4 +1,5 @@
 eggs usr/share/clearwater/homestead/
+_env/lib/python2.7/site-packages/zc.buildout-2.2.0-py2.7.egg usr/share/clearwater/homestead/eggs/
 setup.py usr/share/clearwater/homestead/
 src usr/share/clearwater/homestead/
 modules usr/share/clearwater/homestead/


### PR DESCRIPTION
Andy, as discussed, zc.buildout's egg was missing from the debian package following my earlier fix.  This reinstates it.
