### PR TITLE
[Reviewer: Mike] Mark homer and homestead as suggesting secure connections

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -12,11 +12,11 @@ Homepage: http://projectclearwater.org/
 Package: homer
 Architecture: any
 Depends: clearwater-infrastructure, libxml2-dev, libxslt1-dev, python-setuptools, python-virtualenv, python2.7-dev,  monit, iptables-persistent
-Suggests: clearwater-logging, clearwater-snmpd
+Suggests: clearwater-logging, clearwater-snmpd, clearwater-secure-connections
 Description: homer, the Cassandra powered XDMS
 
 Package: homestead
 Architecture: any
 Depends: clearwater-infrastructure, libxml2-dev, libxslt1-dev, python-setuptools, python-virtualenv, python2.7-dev,  monit, iptables-persistent
-Suggests: clearwater-logging, clearwater-snmpd
+Suggests: clearwater-logging, clearwater-snmpd, clearwater-secure-connections
 Description: homestead, the Cassandra powered HSS gateway


### PR DESCRIPTION
Mike, last one (sorry about these).  Please can you review this fix?  This is similar to the infinispan change to suggest clearwater-secure-connections, but for homer and homestead (because they use Cassandra).
