### PR TITLE
Reviewer Andy: Filtercriteria needs to use ha_get

### DIFF
--- a/src/metaswitch/crest/api/homestead/filtercriteria.py
+++ b/src/metaswitch/crest/api/homestead/filtercriteria.py
@@ -54,7 +54,7 @@ class FilterCriteriaHandler(PassthroughHandler):
     @defer.inlineCallbacks
     def get(self, public_id):
         try:
-            result = yield self.cass.get(column_family=self.table,
+            result = yield self.ha_get(column_family=self.table,
                                          key=public_id,
                                          column=self.column)
             ifc = result.column.value


### PR DESCRIPTION
Filtercriteria doesn't use ha-get, and as such doesn't do quorum reads. It should.  [At least until the new crest code gets checked in and replaces this.]  Tested by running ab against a homestead cluster I'd just grown & seeing that GETs that previously failed now work.
