### PR TITLE
[Reviewer: Rob][From: Alex] Add the _exists column to bulk provisioning (fixes #80)

### DIFF
--- a/src/metaswitch/crest/tools/bulk_create.py
+++ b/src/metaswitch/crest/tools/bulk_create.py
@@ -93,8 +93,8 @@ def standalone():
             homestead_file.write("[ -f %s ] || echo \"The %s file must be present on this system.\"\n" % (homestead_prov_casscli_filename, homestead_prov_casscli_filename))
             homestead_file.write("cassandra-cli -B -f %s\n" % (homestead_cache_casscli_filename))
             homestead_file.write("cassandra-cli -B -f %s\n" % (homestead_prov_casscli_filename))
-            homestead_cache_casscli_file.write("USE homestead_cache;\n");
-            homestead_prov_casscli_file.write("USE homestead_provisioning;\n");
+            homestead_cache_casscli_file.write("USE homestead_cache;\n")
+            homestead_prov_casscli_file.write("USE homestead_provisioning;\n")
 
             # Write Homer/CQL header
             xdm_file.write("#!/bin/bash\n")
@@ -131,7 +131,7 @@ def standalone():
                     def create_row_command(table, row_key):
                         """utility function that writes a row into a homestead
                         keyspace with the required "_exists" field"""
-                        return "SET %s['%s']['_exists'] = '';\n" % (table, row_key))
+                        return "SET %s['%s']['_exists'] = '';\n" % (table, row_key)
 
                     # Add the user to the optimized cassandra cache.
                     homestead_cache_casscli_file.write(
@@ -212,7 +212,7 @@ def standalone():
         print "- %-46s - copy this file onto Homer" % (xdm_cqlsh_filename)
     except IOError as e:
         print "Failed to read/write to %s:" % (e.filename)
-        traceback.print_exc();
+        traceback.print_exc()
 
 if __name__ == '__main__':
     standalone()


### PR DESCRIPTION
Rob, please can you review this change that fixes the bulk provisioning scripts to also set the _exists column for rows in the homestead keyspaces.
