### PR TITLE
[Reviewer: Ellie] Add read/write permissions to generated shell scripts

### DIFF
--- a/src/metaswitch/crest/tools/bulk_create.py
+++ b/src/metaswitch/crest/tools/bulk_create.py
@@ -183,8 +183,8 @@ def standalone():
                     print 'Error: row "%s" contains <4 entries - ignoring'
 
         # Make the created .sh files executable
-        os.chmod(homestead_filename, stat.S_IEXEC)
-        os.chmod(xdm_filename, stat.S_IEXEC)
+        os.chmod(homestead_filename, stat.S_IEXEC|stat.S_IWRITE|stat.S_IREAD)
+        os.chmod(xdm_filename, stat.S_IEXEC|stat.S_IWRITE|stat.S_IREAD)
 
         print "Generated bulk provisioning scripts written to"
         print "- %-46s - run this script on Homestead" % (homestead_filename)


### PR DESCRIPTION
Ellie

Can you review my fix to add rw permissions to the shell scripts generated for bulk provisioning.  I've tested by manually applying the patched file to a homestead node and running the script.

Thanks, Mike
