### PR TITLE
[Reviewer: Andy] Set ipmi's public_id_* column to blank, not to the public ID itself - th...

### DIFF
--- a/src/metaswitch/crest/tools/bulk_create.py
+++ b/src/metaswitch/crest/tools/bulk_create.py
@@ -132,9 +132,8 @@ def standalone():
                     homestead_cache_casscli_file.write(
                         "SET impi['%s']['digest_ha1'] = '%s';\n" % (private_id, hash))
                     homestead_cache_casscli_file.write(
-                        "SET impi['%s']['public_id_%s'] = '%s';\n" % (private_id,
-                                                                      public_id,
-                                                                      public_id))
+                        "SET impi['%s']['public_id_%s'] = '';\n" % (private_id,
+                                                                    public_id))
 
                     homestead_cache_casscli_file.write(
                         create_row_command("impu", public_id))


### PR DESCRIPTION
...ere's no point in repeating it

Andy, please can you review?  The crest code itself would set this column to blank, not to the public user ID, and it's better to duplicate its behavior.

Matt
