### PR TITLE
[Reviewer: Rob][From: Alex] Fix intermittent UT race condition

### DIFF
--- a/src/metaswitch/crest/test/api/base.py
+++ b/src/metaswitch/crest/test/api/base.py
@@ -55,6 +55,15 @@ class TestBaseHandler(unittest.TestCase):
         self.request.headers = {}
         self.handler = base.BaseHandler(self.app, self.request)
 
+        # Mock out zmq so we don't fail if we try to report stats during the
+        # test.
+        self.real_zmq = base.zmq
+        base.zmq = MagicMock()
+
+    def tearDown(self):
+        base.zmq = self.real_zmq
+        del self.real_zmq
+
     def test_prepare(self):
         self.request.headers = {}
         self.handler.prepare()

--- a/src/metaswitch/crest/test/api/homestead/backends/hss/gateway.py
+++ b/src/metaswitch/crest/test/api/homestead/backends/hss/gateway.py
@@ -43,9 +43,10 @@ from twisted.internet import defer
 from twisted.python import failure
 from diameter import stack
 
+import metaswitch.crest.api.base as base
 from metaswitch.crest import settings
 from metaswitch.crest.test import matchers
-from metaswitch.crest.api.base import penaltycounter, digest_latency_accumulator, subscription_latency_accumulator
+from metaswitch.crest.api.base import penaltycounter
 from metaswitch.crest.api.DeferTimeout import TimeoutError
 from metaswitch.crest.api.homestead.backends.hss.gateway import HSSAppListener, HSSGateway, HSSNotEnabled, HSSPeerListener, HSSOverloaded
 
@@ -283,8 +284,14 @@ class TestHSSPeerListener(unittest.TestCase):
         penaltycounter._log = mock.MagicMock()
         penaltycounter.reset_hss_penalty_count()
 
-        digest_latency_accumulator.accumulate = mock.MagicMock()
-        subscription_latency_accumulator.accumulate = mock.MagicMock()
+        # Mock out zmq so we don't fail if we try to report stats during the
+        # test.
+        self.real_zmq = base.zmq
+        base.zmq = mock.MagicMock()
+
+    def tearDown(self):
+        base.zmq = self.real_zmq
+        del self.real_zmq
 
     def test_get_diameter_error_code(self):
         mock_error = mock.MagicMock()


### PR DESCRIPTION
Change the affected tests to mock out the ZMQ interface.

I tested this by:
- Hacking the STATS_PERIOD to 0.1s to reproduce the failures.
- Checking that this codes fixed the tests. 
