### PR TITLE
[Reviewer: Andy] Make the list of supported Cx vendor IDs configurable

### DIFF
--- a/src/metaswitch/crest/api/homestead/backends/hss/gateway.py
+++ b/src/metaswitch/crest/api/homestead/backends/hss/gateway.py
@@ -77,11 +77,10 @@ class HSSGateway(object):
         self.peer_listener = HSSPeerListener(app,
                                              settings.SIP_DIGEST_REALM,
                                              dstack)
-        dstack.addSupportedVendor(10415)
-        dstack.addSupportedVendor(13019)
         dstack.registerApplication(app, 0, 16777216)
-        dstack.registerApplication(app, 10415, 16777216)
-        dstack.registerApplication(app, 13019, 16777216)
+        for vendor in settings.CX_SUPPORTED_VENDORS:
+            dstack.addSupportedVendor(vendor)
+            dstack.registerApplication(app, vendor, 16777216)
         dstack.registerPeerListener(self.peer_listener)
         dstack.registerPeerIO(HSSPeerIO())
         dstack.clientV4Add(settings.HSS_IP, settings.HSS_PORT)

--- a/src/metaswitch/crest/settings.py
+++ b/src/metaswitch/crest/settings.py
@@ -118,6 +118,10 @@ HSS_IMS_SUB_CACHE_PERIOD_SECS=7 * 24 * 60 * 60
 # changed by creating a local_settings.py file in this directory.
 CYCLONE_DEBUG = False  # Make cyclone emit debug messages to the browser etc.
 
+# Set of vendor IDs to include on Cx CER.  As 3GPP TS 29.229 Section 5.6, the
+# default is both 3GPP (10415) and ETSI (13019), but this can be overridden.
+CX_SUPPORTED_VENDORS = [10415, 13019]
+
 # Include any locally-defined settings.
 _local_settings_file = os.path.join(_MY_DIR, "local_settings.py")
 if os.path.exists(_local_settings_file):


### PR DESCRIPTION
Fixes #117 

Andy, please can you review my fix to make the list of supported Cx vendor IDs configurable.  It can now be overridden in `local_settings.py` to remove ETSI from the list.  I've tested both the default behavior and the overridden behavior against OpenIMS HSS and checked the flows are as expected and that OpenIMS HSS accepts them.
