### PR TITLE
[Reviewer: Rob] Sprout port is 5054, not 5058

### DIFF
--- a/src/metaswitch/crest/settings.py
+++ b/src/metaswitch/crest/settings.py
@@ -92,7 +92,7 @@ CASS_PORT = 9160
 # Debian install will pick this up from /etc/clearwater/config
 LOCAL_IP = "127.0.0.1"
 SPROUT_HOSTNAME = "sprout.%s" % SIP_DIGEST_REALM
-SPROUT_PORT = 5058
+SPROUT_PORT = 5054
 PUBLIC_HOSTNAME = "hs.%s" % SIP_DIGEST_REALM
 HS_HOSTNAME = "hs.%s" % SIP_DIGEST_REALM
 


### PR DESCRIPTION
Rob,

Please can you review my fix?  Homestead registers with the HSS setting Server-Name to the sprout hostname and port 5058.  It should register with port 5054.

Tested live and UT run (although this configuration is not tested by UT).

Matt
