### PR TITLE
[Reviewer Ellie] Switch Homestead back to specify port 5054 in Server Assignment Requests

### DIFF
--- a/src/metaswitch/crest/settings.py
+++ b/src/metaswitch/crest/settings.py
@@ -92,7 +92,7 @@ CASS_PORT = 9160
 # Debian install will pick this up from /etc/clearwater/config
 LOCAL_IP = "127.0.0.1"
 SPROUT_HOSTNAME = "sprout.%s" % SIP_DIGEST_REALM
-SPROUT_PORT = 5052
+SPROUT_PORT = 5054
 PUBLIC_HOSTNAME = "hs.%s" % SIP_DIGEST_REALM
 HS_HOSTNAME = "hs.%s" % SIP_DIGEST_REALM
 


### PR DESCRIPTION
I lied - I do need one more thing from you!  Can you quickly review this change to flip Homestead back to use port 5054 on SARs.

Thanks, Mike
