### PR TITLE
[Reviewer: AMC] Add a CCF setting and provision subscribers with it

### DIFF
--- a/homestead.local_settings/local_settings.py
+++ b/homestead.local_settings/local_settings.py
@@ -56,6 +56,7 @@ SPROUT_HOSTNAME = MUST_BE_CONFIGURED
 PUBLIC_HOSTNAME = MUST_BE_CONFIGURED
 HS_HOSTNAME = MUST_BE_CONFIGURED
 LOWERCASE_UNKNOWN = False
+CCF = ""
 
 # We use this key to encrypt sensitive fields in the database that we can't
 # avoid storing.  In general, we'd like to store passwords as bcrypt hashes

--- a/homestead.root/usr/share/clearwater/infrastructure/scripts/homestead-prov
+++ b/homestead.root/usr/share/clearwater/infrastructure/scripts/homestead-prov
@@ -34,7 +34,8 @@ sed -e 's/^LOCAL_IP = .*$/LOCAL_IP = "'$local_ip'"/g
         s/^HTTP_PORT = .*$/HTTP_PORT = '$homestead_provisioning_port'/g
         s/^PASSWORD_ENCRYPTION_KEY = .*$/PASSWORD_ENCRYPTION_KEY = "'$homestead_password_encryption_key'"/g
         s/^LOCAL_PROVISIONING_ENABLED = .*$/LOCAL_PROVISIONING_ENABLED = '$local_prov_setting'/g
-        s/^CASS_HOST = .*$/CASS_HOST = "'$cassandra_hostname'"/g' \
+        s/^CASS_HOST = .*$/CASS_HOST = "'$cassandra_hostname'"/g
+        s/^CCF = .*$/CCF = "'$cdf_identity'"/g' \
             </usr/share/clearwater/homestead/src/metaswitch/crest/local_settings.py >/tmp/local_settings.py.$$
 
 for dst in /usr/share/clearwater/homestead/src/metaswitch/crest/local_settings.py \

--- a/src/metaswitch/crest/api/homestead/cache/db.py
+++ b/src/metaswitch/crest/api/homestead/cache/db.py
@@ -36,6 +36,7 @@ from twisted.internet import defer
 import logging
 
 from .. import config
+from metaswitch.crest import settings
 from ..cassandra import CassandraModel
 from telephus.cassandra.ttypes import NotFoundException
 
@@ -113,6 +114,7 @@ class IMPI(CacheModel):
         yield cls.delete_rows(private_ids, timestamp=timestamp)
 
 IMS_SUBSCRIPTION = "ims_subscription_xml"
+PRIMARY_CCF = "primary_ccf"
 
 
 class IMPU(CacheModel):
@@ -129,7 +131,8 @@ class IMPU(CacheModel):
 
     @defer.inlineCallbacks
     def put_ims_subscription(self, ims_subscription, ttl=None, timestamp=None):
-        yield self.modify_columns({IMS_SUBSCRIPTION: ims_subscription},
+        yield self.modify_columns({IMS_SUBSCRIPTION: ims_subscription,
+                                   PRIMARY_CCF: settings.CCF},
                                   ttl=ttl,
                                   timestamp=timestamp)
 

--- a/src/metaswitch/crest/settings.py
+++ b/src/metaswitch/crest/settings.py
@@ -96,6 +96,7 @@ SPROUT_HOSTNAME = "sprout.%s" % SIP_DIGEST_REALM
 SPROUT_PORT = 5054
 PUBLIC_HOSTNAME = "hs.%s" % SIP_DIGEST_REALM
 HS_HOSTNAME = "hs.%s" % SIP_DIGEST_REALM
+CCF = "ccf"
 
 # Cache period (in seconds) for authentication details retrieved from the HSS.
 # There is no way to be notified of authentication changes over the Cx

--- a/src/metaswitch/crest/test/api/homestead/cache/cache.py
+++ b/src/metaswitch/crest/test/api/homestead/cache/cache.py
@@ -174,7 +174,7 @@ class TestCache(unittest.TestCase):
         self.cass_client.batch_insert.assert_called_once_with(
                                         key="pub",
                                         column_family="impu",
-                                        mapping=DictContaining({"ims_subscription_xml": "xml"}),
+                                        mapping=DictContaining({"ims_subscription_xml": "xml", "primary_ccf": "ccf"}),
                                         ttl=self.ttl,
                                         timestamp=self.timestamp)
         batch_insert.callback(None)


### PR DESCRIPTION
Provision subscribers with the primary ccf set to a configured value taken from /etc/clearwater/config. If one isn't present, we provision the subscriber with ccf equal to the empty string, which is the same as there not being a ccf.

Not live tested yet.
