### PR TITLE
Reviewer Ellie: Don't push IRSs to homestead_cache unless they contain a SIP URI

### DIFF
--- a/src/metaswitch/crest/api/exceptions.py
+++ b/src/metaswitch/crest/api/exceptions.py
@@ -58,3 +58,8 @@ class UserNotIdentifiable(Exception):
 class UserNotAuthorized(Exception):
     """Exception to throw if we are unable to authorize a user"""
     pass
+
+# IRS-specific Exceptions
+class IRSNoSIPURI(Exception):
+    """Exception to throw if we are creating an IRS with no SIP URI"""
+    pass


### PR DESCRIPTION
Ellie, please can you review this change to stop us from pushing Implicit Registration Sets that don't contain a SIP URI to homestead_cache.

If you have any questions or suggestions of what I should have done better, I'm happy to talk at great length as to why I've done what I've done.

Also, we currently have no UTs for the code I've changed. I haven't added any. I've live tested this pretty extensively though.
