### PR TITLE
[Reviewer: Matt] Move homestead-prov to it's own unix domain socket

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -60,7 +60,7 @@ Pre-requisites
 6. ZMQ libraries
 
    ```
-   sudo apt-get install python-zmq libzmq3-dev 
+   sudo apt-get install python-zmq libzmq3-dev
    ```
 
 Setting up a virtualenv
@@ -90,8 +90,8 @@ that could be put at the bottom of `settings.py` can be put in `local_settings.p
 For a homestead node, you'll probably need at least the following in
 `local_settings.py` (replacing `example.com` with the correct domain).
 
-    LOG_FILE_PREFIX = "homestead"
-    PROCESS_NAME = "homestead"
+    LOG_FILE_PREFIX = "homestead-prov"
+    PROCESS_NAME = "homestead-prov"
     INSTALLED_HANDLERS = ["homestead"]
     HTTP_PORT = 8888
     HSS_ENABLED = False

--- a/homestead.local_settings/local_settings.py
+++ b/homestead.local_settings/local_settings.py
@@ -32,7 +32,7 @@
 # under which the OpenSSL Project distributes the OpenSSL toolkit software,
 # as those licenses appear in the file LICENSE-OPENSSL.
 
-PROCESS_NAME="homestead"
+PROCESS_NAME="homestead-prov"
 LOGS_DIR = "/var/log/homestead-prov"
 PID_FILE = "/var/run/homestead-prov.pid"
 LOG_FILE_PREFIX = "homestead-prov"


### PR DESCRIPTION
Matt, please could you review this change for https://github.com/Metaswitch/clearwater-snmp-handlers/issues/36. It changes the name of the unix domain socket that homestead-prov uses for stats from `homestead` (which conflicts with the homestead process) to `homestead-prov`. This doesn't completely fix the issue, but it makes it less severe. 

Tested as follows. Stats were retrieved using the command `snmpwalk -v2c -c clearwater homestead-1.ajh.cw-ngv.com 1.2.826.0.1.1578918.9`

* Initial install, stats returned. **Failed** (due to https://github.com/Metaswitch/clearwater-snmp-handlers/issues/37)
* Restart SNMP, stats returned. Passed.
* Restart homestead, stats returned. Passed.
* Restart homestead-prov, stats returned. Passed.
* Reboot node, stats returned. Passed.
* Start a second homestead process from the command line. stats returned from original process **Failed**. This is the part of https://github.com/Metaswitch/clearwater-snmp-handlers/issues/36 that is not fixed, but that we're planning to fix eventually with lockfiles. 
* Live tests run successfully (to confirm homestead-prov is working). Passed.

This PR contains the necessary docs updates. 