### PR TITLE
Reviewer Ellie - Set up sites-enabled in infrastructure script

### DIFF
--- a/debian/homestead-prov.postinst
+++ b/debian/homestead-prov.postinst
@@ -56,10 +56,6 @@ HOMESTEAD_DIR=/usr/share/clearwater/homestead
 
 case "$1" in
     configure)
-        # Restart clearwater-infrastructure to run the script that creates the
-        # homestead-prov nginx site.
-        service clearwater-infrastructure restart
-
         rm -rf $HOMESTEAD_DIR/build
         virtualenv --python=$(which python) $HOMESTEAD_DIR/env
         $HOMESTEAD_DIR/env/bin/easy_install --allow-hosts=None -f $HOMESTEAD_DIR/eggs/ $HOMESTEAD_DIR/eggs/*.egg
@@ -73,7 +69,10 @@ case "$1" in
             cd -
         done
 
-        /usr/share/clearwater/infrastructure/scripts/homestead-prov
+        # Restart clearwater-infrastructure to run the script that creates the
+        # homestead-prov nginx site.
+        service clearwater-infrastructure restart
+
         /usr/share/clearwater/cassandra-schemas/homestead_provisioning.sh || true
 
         # Start monit monitoring ourselves
@@ -87,12 +86,6 @@ case "$1" in
 
         # Apply secure connection rules if enabled.
         [ ! -x /etc/init.d/clearwater-secure-connections ] || /etc/init.d/clearwater-secure-connections reload
-
-        # Enable the homestead-prov nginx site
-        if ( nginx_ensite homestead-prov > /dev/null )
-        then
-            service nginx stop
-        fi
     ;;
 
     abort-upgrade|abort-remove|abort-deconfigure)

--- a/homestead.root/usr/share/clearwater/infrastructure/scripts/create-homestead-prov-nginx-config
+++ b/homestead.root/usr/share/clearwater/infrastructure/scripts/create-homestead-prov-nginx-config
@@ -54,18 +54,19 @@ read -r hs_provisioning_domain hs_provisioning_port <<< "$(split_domain_and_port
 [ ! -z $homestead_provisioning_port ] || homestead_provisioning_port=$hs_provisioning_port
 
 site_file=/etc/nginx/sites-available/homestead-prov
+temp_file=$(mktemp homestead-prov.nginx.XXXXXXXX)
 let sock_seq_end=$(cat /proc/cpuinfo | grep processor | wc -l)-1
 
-cat > $site_file << EOF1
+cat > $temp_file << EOF1
 upstream http_homestead_prov {
 EOF1
 
 for sock_index in `seq 0 $sock_seq_end`;
 do
-  echo "        server unix:/tmp/.homestead-prov-sock-$sock_index;" >> $site_file
+  echo "        server unix:/tmp/.homestead-prov-sock-$sock_index;" >> $temp_file
 done
 
-cat >> $site_file << EOF2
+cat >> $temp_file << EOF2
 
         # The minimum number of idle connections to keep alive to the upstream.
         keepalive 16;
@@ -85,3 +86,17 @@ server {
         }
 }
 EOF2
+
+if ! diff $temp_file $site_file > /dev/null 2>&1
+then
+  # Update the site file
+  mv $temp_file $site_file
+
+  # Enable the homestead-prov nginx site
+  if ( nginx_ensite homestead-prov > /dev/null )
+  then
+    service nginx stop
+  fi
+else
+  rm $temp_file
+fi


### PR DESCRIPTION
Enable the homestead-prov site in clearwater infra rather than at install time so we can learn shared config late.