### PR TITLE
Reviewer Graeme - Diff against the symlink, not the main file

### DIFF
--- a/homer.root/usr/share/clearwater/infrastructure/scripts/create-homer-nginx-config
+++ b/homer.root/usr/share/clearwater/infrastructure/scripts/create-homer-nginx-config
@@ -52,6 +52,7 @@ fi
 read -r xdms_domain xdms_port <<< "$(split_domain_and_port $xdms_hostname)"
 
 site_file=/etc/nginx/sites-available/homer
+enabled_file=/etc/nginx/sites-enabled/homer
 temp_file=$(mktemp homer.nginx.XXXXXXXX)
 let sock_seq_end=$(cat /proc/cpuinfo | grep processor | wc -l)-1
 
@@ -85,7 +86,7 @@ server {
 }
 EOF2
 
-if ! diff $temp_file $site_file > /dev/null 2>&1
+if ! diff $temp_file $enabled_file > /dev/null 2>&1
 then
   # Update the site file
   mv $temp_file $site_file

--- a/homestead.root/usr/share/clearwater/infrastructure/scripts/create-homestead-prov-nginx-config
+++ b/homestead.root/usr/share/clearwater/infrastructure/scripts/create-homestead-prov-nginx-config
@@ -54,6 +54,7 @@ read -r hs_provisioning_domain hs_provisioning_port <<< "$(split_domain_and_port
 [ ! -z $homestead_provisioning_port ] || homestead_provisioning_port=$hs_provisioning_port
 
 site_file=/etc/nginx/sites-available/homestead-prov
+enabled_file=/etc/nginx/sites-enabled/homestead-prov
 temp_file=$(mktemp homestead-prov.nginx.XXXXXXXX)
 let sock_seq_end=$(cat /proc/cpuinfo | grep processor | wc -l)-1
 
@@ -87,7 +88,7 @@ server {
 }
 EOF2
 
-if ! diff $temp_file $site_file > /dev/null 2>&1
+if ! diff $temp_file $enabled_file > /dev/null 2>&1
 then
   # Update the site file
   mv $temp_file $site_file


### PR DESCRIPTION
This means that we'll catch the case where the symlink is missing (i.e. the site's not enabled) since `diff` returns 2 in the case that one of it's specified files can't be opened.