### PR TITLE
[Reviewer: Ellie] Document the /ping endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Further info
 * [Design guide](docs/design.md)
 * [Development guide](docs/development.md)
 * [Homer API guide](docs/homer_api.md)
-* [Homestead API guide](docs/homesteadi_prov_api.md)
+* [Homestead API guide](docs/homestead_prov_api.md)
 * [Homer Feature List](docs/homer_features.md)
 * [Homestead Feature List](docs/homestead_prov_features.md)
 * [Changelog](CHANGELOG.md)

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ Further info
 * [Design guide](docs/design.md)
 * [Development guide](docs/development.md)
 * [Homer API guide](docs/homer_api.md)
-* [Homestead API guide](docs/homestead_api.md)
+* [Homestead API guide](docs/homesteadi_prov_api.md)
 * [Homer Feature List](docs/homer_features.md)
-* [Homestead Feature List](docs/homestead_features.md)
+* [Homestead Feature List](docs/homestead_prov_features.md)
 * [Changelog](CHANGELOG.md)
 

--- a/docs/homer_api.md
+++ b/docs/homer_api.md
@@ -4,6 +4,13 @@ Homer - API Guide
 Homer provides a RESTful API. This is used by the Ellis and Sprout components. 
 All access must go via this API, rather than directly to the database.
 
+Liveness checking
+==================
+
+    /ping
+
+Make a GET request to this endpoint to check whether Homer is running. It will return 200 OK if so.
+
 Simservs documents
 ==================
 

--- a/docs/homestead_prov_api.md
+++ b/docs/homestead_prov_api.md
@@ -4,6 +4,12 @@ Homestead-prov provides a RESTful API. This is used by the Ellis component to cr
 
 All access must go via this API, rather than directly to the database. 
 
+## Liveness checking
+
+    /ping
+
+Make a GET request to this endpoint to check whether Homestead-prov is running. It will return 200 OK if so.
+
 ## IMPI
 
     /impi/<private ID>/digest


### PR DESCRIPTION
We had a mailing list question about it, so I thought the `/ping` URL should be in the API docs.