### PR TITLE
[Reviewer: Rob] Check config is available

### DIFF
--- a/homer.root/usr/share/clearwater/infrastructure/scripts/create-homer-nginx-config
+++ b/homer.root/usr/share/clearwater/infrastructure/scripts/create-homer-nginx-config
@@ -43,6 +43,10 @@ split_domain_and_port()
 
 . /etc/clearwater/config
 
+# Only create the nginx config if the xdms_hostname has been set.
+# We need this configuration when Homer is running on a multiple
+# networks system; if this isn't created then poll_homer will fail
+# and cyclically reboot Homer (on a multiple networks system)
 if [ -n "$xdms_hostname" ]
 then
   read -r xdms_domain xdms_port <<< "$(split_domain_and_port $xdms_hostname)"

--- a/homer.root/usr/share/clearwater/infrastructure/scripts/create-homer-nginx-config
+++ b/homer.root/usr/share/clearwater/infrastructure/scripts/create-homer-nginx-config
@@ -43,27 +43,23 @@ split_domain_and_port()
 
 . /etc/clearwater/config
 
-if [ -z $xdms_hostname ]
+if [ -n "$xdms_hostname" ]
 then
-  echo "xdms_hostname is not defined"
-  exit
-fi
+  read -r xdms_domain xdms_port <<< "$(split_domain_and_port $xdms_hostname)"
 
-read -r xdms_domain xdms_port <<< "$(split_domain_and_port $xdms_hostname)"
+  site_file=/etc/nginx/sites-available/homer
+  enabled_file=/etc/nginx/sites-enabled/homer
+  temp_file=$(mktemp homer.nginx.XXXXXXXX)
+  let sock_seq_end=$(cat /proc/cpuinfo | grep processor | wc -l)-1
 
-site_file=/etc/nginx/sites-available/homer
-enabled_file=/etc/nginx/sites-enabled/homer
-temp_file=$(mktemp homer.nginx.XXXXXXXX)
-let sock_seq_end=$(cat /proc/cpuinfo | grep processor | wc -l)-1
-
-cat > $temp_file << EOF1
+  cat > $temp_file << EOF1
 upstream http_homer {
 EOF1
 
-for sock_index in `seq 0 $sock_seq_end`;
-do
-  echo "        server unix:/tmp/.homer-sock-$sock_index;" >> $temp_file
-done
+  for sock_index in `seq 0 $sock_seq_end`;
+  do
+    echo "        server unix:/tmp/.homer-sock-$sock_index;" >> $temp_file
+  done
 
 cat >> $temp_file << EOF2
 
@@ -86,16 +82,17 @@ server {
 }
 EOF2
 
-if ! diff $temp_file $enabled_file > /dev/null 2>&1
-then
-  # Update the site file
-  mv $temp_file $site_file
-
-  # Enable the homestead-prov nginx site
-  if ( nginx_ensite homer > /dev/null )
+  if ! diff $temp_file $enabled_file > /dev/null 2>&1
   then
-    service nginx stop
+    # Update the site file
+    mv $temp_file $site_file
+
+    # Enable the homestead-prov nginx site
+    if ( nginx_ensite homer > /dev/null )
+    then
+      service nginx stop
+    fi
+  else
+    rm $temp_file
   fi
-else
-  rm $temp_file
 fi

--- a/homer.root/usr/share/clearwater/infrastructure/scripts/homer
+++ b/homer.root/usr/share/clearwater/infrastructure/scripts/homer
@@ -1,18 +1,61 @@
 #!/bin/bash
+
+# @file homer
+#
+# Project Clearwater - IMS in the Cloud
+# Copyright (C) 2013 Metaswitch Networks Ltd
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version, along with the "Special Exception" for use of
+# the program along with SSL, set forth below. This program is distributed
+# in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details. You should have received a copy of the GNU General Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/>.
+#
+# The author can be reached by email at clearwater@metaswitch.com or by
+# post at Metaswitch Networks Ltd, 100 Church St, Enfield EN2 6BQ, UK
+#
+# Special Exception
+# Metaswitch Networks Ltd  grants you permission to copy, modify,
+# propagate, and distribute a work formed by combining OpenSSL with The
+# Software, or a work derivative of such a combination, even if such
+# copying, modification, propagation, or distribution would otherwise
+# violate the terms of the GPL. You must comply with the GPL in all
+# respects for all of the code used other than OpenSSL.
+# "OpenSSL" means OpenSSL toolkit software distributed by the OpenSSL
+# Project and licensed under the OpenSSL Licenses, or a work based on such
+# software and licensed under the OpenSSL Licenses.
+# "OpenSSL Licenses" means the OpenSSL License and Original SSLeay License
+# under which the OpenSSL Project distributes the OpenSSL toolkit software,
+# as those licenses appear in the file LICENSE-OPENSSL.
+
 # Set default values which will be overwritten if they exist in /etc/clearwater/config
 cassandra_hostname="localhost" 
 . /etc/clearwater/config
-function escape { echo $1 | sed -e 's/\//\\\//g' ; }
-sed -e 's/^LOCAL_IP = .*$/LOCAL_IP = "'$(escape $local_ip)'"/g
-        s/^SIP_DIGEST_REALM = .*$/SIP_DIGEST_REALM = "'$(escape $home_domain)'"/g
-        s/^SPROUT_HOSTNAME = .*$/SPROUT_HOSTNAME = "'$(escape $sprout_hostname)'"/g
-        s/^CASS_HOST = .*$/CASS_HOST = "'$(escape $cassandra_hostname)'"/g' </usr/share/clearwater/homer/src/metaswitch/crest/local_settings.py >/tmp/local_settings.py.$$
-for dst in /usr/share/clearwater/homer/src/metaswitch/crest/local_settings.py \
-           /usr/share/clearwater/homer/env/lib/python2.7/site-packages/crest-0.1-py2.7.egg/metaswitch/crest/local_settings.py
-do
-  if [ -f $dst ]
-  then
-    cp /tmp/local_settings.py.$$ $dst
-  fi
-done
-rm /tmp/local_settings.py.$$
+
+# Only modify local_settings if the home_domain, sprout_hostname and local_ip
+# are available (they might not be if shared_config hasn't been propagated
+# round the deployment yet). Homer will cyclically restart until this has
+# been set up correctly
+if [ -n "$home_domain" ] && [ -n "$sprout_hostname" ] && [ -n "$local_ip" ]
+then
+  function escape { echo $1 | sed -e 's/\//\\\//g' ; }
+  sed -e 's/^LOCAL_IP = .*$/LOCAL_IP = "'$(escape $local_ip)'"/g
+          s/^SIP_DIGEST_REALM = .*$/SIP_DIGEST_REALM = "'$(escape $home_domain)'"/g
+          s/^SPROUT_HOSTNAME = .*$/SPROUT_HOSTNAME = "'$(escape $sprout_hostname)'"/g
+          s/^CASS_HOST = .*$/CASS_HOST = "'$(escape $cassandra_hostname)'"/g' </usr/share/clearwater/homer/src/metaswitch/crest/local_settings.py >/tmp/local_settings.py.$$
+  for dst in /usr/share/clearwater/homer/src/metaswitch/crest/local_settings.py \
+             /usr/share/clearwater/homer/env/lib/python2.7/site-packages/crest-0.1-py2.7.egg/metaswitch/crest/local_settings.py
+  do
+    if [ -f $dst ]
+    then
+      cp /tmp/local_settings.py.$$ $dst
+    fi
+  done
+  rm /tmp/local_settings.py.$$
+fi


### PR DESCRIPTION
This changes means the scripts only set up the local_settings file and nginx config if sufficient configuration is available. Homer will cyclically reboot until these files have been created. 

This is a partial fix for the general issue in #224, if this is OK I'll make the same changes to the other repos. 