### PR TITLE
[Reviewer: Ellie] Unbind ZMQ when shutting down to ensure clean termination

### DIFF
--- a/src/metaswitch/crest/api/base.py
+++ b/src/metaswitch/crest/api/base.py
@@ -212,6 +212,9 @@ def setupStats(p_id, worker_proc):
     incoming_requests.set_process_id(p_id)
     overload_counter.set_process_id(p_id)
 
+def shutdownStats():
+    zmq.unbind()
+
 def _guess_mime_type(body):
     if (body == "null" or
         (body[0] == "{" and


### PR DESCRIPTION
Ellie,

Please can you review this?  (One aspect of #223.)

Previously, on `service homestead-prov stop` we caught the `SIGTERM` but didn't shut down ZMQ, so the Twisted reactor still kept running and we waited until the `SIGKILL` to terminate.  Now, we honor the `SIGTERM` and tidy up ZMQ, and hence close the whole process down.

Tested live.

Thanks,

Matt