### PR TITLE
[Reviewer: Ellie] Remove debugging trace statement that is now spammy

### DIFF
--- a/src/metaswitch/crest/api/homestead/cache/db.py
+++ b/src/metaswitch/crest/api/homestead/cache/db.py
@@ -68,7 +68,6 @@ class IMPI(CacheModel):
 
             realm = columns.get(DIGEST_REALM, None)
             qop = columns.get(DIGEST_QOP, None)
-            _log.error("Value in DB is %r", columns.get(KNOWN_PREFERRED))
             preferred = (columns.get(KNOWN_PREFERRED, '\x01') == '\x01')
 
             # It the user has supplied a public ID, they care about whether the


### PR DESCRIPTION
Ellie,

Please can you review this?  (One aspect of #223.)  Basically, we had log spam from a trace that was error-level, but should have been much lower.  Investigating further, it looks like this was intended to troubleshoot a specific issue that is now resolved, so I've removed it entirely.

Matt