### PR TITLE
[Reviewer: Ellie] Add a /public/ API for querying all SIP URIs

### DIFF
--- a/docs/homestead_prov_api.md
+++ b/docs/homestead_prov_api.md
@@ -201,3 +201,48 @@ Make a GET to this URL to list the private IDs that can authenticate the public 
 
 * 200 if the public IDs exists, returned as JSON: `{ "private_ids": ["<private-id-1>", "<private-id-2>"] }`
 * 404 if the public ID does not exist.
+
+`/public/?excludeuuids=[true|false]&chunk-proportion=N`
+
+Make a GET to this URL to list all public IDs provisioned on the system.
+
+Parameters:
+
+* excludeuuids (boolean, default false) - This API can provide the service profile and implicit
+    registration set UUIDs for each public ID. This requires more database lookups, so can be
+    disabled for a faster, less CPU-intensive query if they aren't needed.
+* chunk-proportion (integer, default 256) - Internally, Homestead breaks the subscriber base into
+    this many chunks, and pauses for 1 second between querying each one. Reducing this value will
+    result in a faster response, but will be less well-paced (with a higher risk of disrupting
+    service), and as Homestead handles more data at once, results in higher memory usage. The value
+    of 256 has proved to work well in testing.
+
+This API does a lot more work than the others, so it tends to be slower - as a rough guide, from
+testing on a 1-core VM:
+
+* retrieving 100k subscribers with excludeuuids=false takes 520 seconds - 264 seconds plus 256 1-second pauses for pacing
+* retrieving 100k subscribers with excludeuuids=true takes 264 seconds - 8 seconds plus 256 1-second pauses for pacing
+
+The response is always 200 OK, with a JSON body in the following form:
+
+```
+{"public_ids":
+  [
+    {"public_id": "sip:a@example.com",
+     "sp": "fbfb0fa8-ac91-46a9-907a-1408fa0b521f",
+     "irs": "51ca6207-9261-4199-aef0-8da6fb1fdafd"},
+    {"public_id": "sip:b@example.com",
+     "sp": "fbfb0fa8-ac91-46a9-907a-1408fa0b521f",
+     "irs": "51ca6207-9261-4199-aef0-8da6fb1fdafd"},
+]}
+```
+
+or, if excludeuuids is true:
+
+```
+{"public_ids":
+  [
+    {"public_id": "sip:a@example.com"},
+    {"public_id": "sip:b@example.com"},
+]}
+```

--- a/src/metaswitch/crest/api/homestead/__init__.py
+++ b/src/metaswitch/crest/api/homestead/__init__.py
@@ -42,7 +42,7 @@ from .cache.handlers import DigestHandler, AuthVectorHandler, IMSSubscriptionHan
 from .provisioning.handlers.private import PrivateHandler, PrivateAllIrsHandler, PrivateOneIrsHandler, PrivateAllPublicIdsHandler
 from .provisioning.handlers.irs import AllIRSHandler, IRSHandler, IRSAllPublicIDsHandler, IRSAllPrivateIDsHandler, IRSPrivateIDHandler
 from .provisioning.handlers.service_profile import AllServiceProfilesHandler, ServiceProfileHandler, SPAllPublicIDsHandler, SPPublicIDHandler, SPFilterCriteriaHandler
-from .provisioning.handlers.public import PublicIDServiceProfileHandler, PublicIDIRSHandler, PublicIDPrivateIDHandler
+from .provisioning.handlers.public import PublicIDServiceProfileHandler, PublicIDIRSHandler, PublicIDPrivateIDHandler, AllPublicIDsHandler
 
 from .cache.db import IMPI, IMPU, CacheModel
 from .provisioning.models import PrivateID, IRS, ServiceProfile, PublicID, ProvisioningModel
@@ -169,6 +169,9 @@ PROVISIONING_ROUTES = [
 
     # List all private IDs that can authenticate this public ID.
     (r'/public/'+ANY+r'/associated_private_ids/?', PublicIDPrivateIDHandler),
+
+    # List all public IDs
+    (r'/public/?', AllPublicIDsHandler),
 ]
 
 ROUTES = CACHE_ROUTES

--- a/src/metaswitch/crest/api/homestead/provisioning/handlers/public.py
+++ b/src/metaswitch/crest/api/homestead/provisioning/handlers/public.py
@@ -54,7 +54,7 @@ JSON_PRIVATE_IDS = "private_ids"
 class AllPublicIDsHandler(BaseHandler):
     @defer.inlineCallbacks
     def get(self):
-        num_chunks = int(self.get_argument("chunk-proportion", default=1))
+        num_chunks = int(self.get_argument("chunk-proportion", default=256))
         fast = (self.get_argument("fast", default="false") == "true")
         _log.info("Retrieving all public IDs (broken into {} chunks)".format(num_chunks))
 
@@ -83,8 +83,8 @@ class AllPublicIDsHandler(BaseHandler):
                 # Retrieving these UUIDs is time-consuming and may not be
                 # necessary - skip them if "fast=true" is given in the URL.
                 if not fast:
-                    sp = yield p.get_sp()
-                    irs = yield p.get_irs()
+                    sp = yield p.get_sp_str()
+                    irs = yield p.get_irs_str()
 
                 if first:
                     first = False

--- a/src/metaswitch/crest/api/homestead/provisioning/handlers/public.py
+++ b/src/metaswitch/crest/api/homestead/provisioning/handlers/public.py
@@ -32,13 +32,76 @@
 # under which the OpenSSL Project distributes the OpenSSL toolkit software,
 # as those licenses appear in the file LICENSE-OPENSSL.
 
-from twisted.internet import defer
+from twisted.internet import defer, reactor
 from telephus.cassandra.ttypes import NotFoundException
 from metaswitch.crest.api.base import BaseHandler
+import json
+import logging
 
 from ..models import PublicID
 
+_log = logging.getLogger("crest.api.homestead.provisioning")
+
+# Twisted-friendly non-blocking sleep function
+def sleep(seconds):
+    d = defer.Deferred()
+    reactor.callLater(seconds, d.callback, seconds)
+    return d
+
+
 JSON_PRIVATE_IDS = "private_ids"
+
+class AllPublicIDsHandler(BaseHandler):
+    @defer.inlineCallbacks
+    def get(self):
+        num_chunks = int(self.get_argument("chunk-proportion", default=1))
+        fast = (self.get_argument("fast", default="false") == "true")
+        _log.info("Retrieving all public IDs (broken into {} chunks)".format(num_chunks))
+
+        # Break the Cassandra ring down into chunks
+        min_token = -2**63;
+        max_token = (2**63)-1;
+
+        chunk_size = (max_token - min_token) / num_chunks
+
+        start = min_token
+        end = start + chunk_size
+
+        # Query all subscribers, chunk-by-chunk, and stream it back to the
+        # client
+        first = True
+        self.write('{"public_ids": [')
+        while start < max_token:
+            if not first:
+                yield sleep(1)
+
+            result = yield PublicID.get_chunk(start=str(start), finish=str(end))
+            for p in result:
+                sp = None
+                irs = None
+
+                # Retrieving these UUIDs is time-consuming and may not be
+                # necessary - skip them if "fast=true" is given in the URL.
+                if not fast:
+                    sp = yield p.get_sp()
+                    irs = yield p.get_irs()
+
+                if first:
+                    first = False
+                else:
+                    self.write(',')
+
+                self.write(json.dumps({"public_id": p.row_key_str,
+                                       "sp": sp,
+                                       "irs": irs
+                                       }))
+            self.flush()
+            start = end
+            end = min([max_token, start + chunk_size])
+
+        self.write(']}')
+
+        self.finish()
 
 
 class PublicIDServiceProfileHandler(BaseHandler):

--- a/src/metaswitch/crest/api/homestead/provisioning/models.py
+++ b/src/metaswitch/crest/api/homestead/provisioning/models.py
@@ -394,6 +394,22 @@ class PublicID(ProvisioningModel):
         private_ids = yield IRS(irs_uuid).get_associated_privates()
         defer.returnValue(private_ids)
 
+    @classmethod
+    @defer.inlineCallbacks
+    def get_chunk(self, start, finish):
+        # Query an appropiate section of the Cassandra ring. Because we're
+        # limiting the query by token, we can accept an unrestricted number of
+        # results (10M is our max recommended size).
+        values = yield self.client.get_range_slices(column_family=self.cass_table,
+                                                    start=start,
+                                                    finish=finish,
+                                                    use_tokens=True,
+                                                    count=10000000)
+        keys = [x.key for x in values]
+        public_ids = [PublicID(x) for x in keys]
+        _log.info("Queried tokens {} to {} - received {} results".format(start, finish, len(public_ids)))
+        defer.returnValue(public_ids)
+
     @defer.inlineCallbacks
     def put_publicidentity(self, xml, sp_uuid):
         yield self.modify_columns({self.PUBLICIDENTITY: xml,

--- a/src/metaswitch/crest/api/homestead/provisioning/models.py
+++ b/src/metaswitch/crest/api/homestead/provisioning/models.py
@@ -377,6 +377,11 @@ class PublicID(ProvisioningModel):
         defer.returnValue(sp_uuid)
 
     @defer.inlineCallbacks
+    def get_sp_str(self):
+        sp_uuid = yield self.get_sp()
+        defer.returnValue(uuid_to_str(sp_uuid))
+
+    @defer.inlineCallbacks
     def get_publicidentity(self):
         _log.debug("Create public ID %s" % self.row_key_str)
         xml = yield self.get_column_value(self.PUBLICIDENTITY)
@@ -387,6 +392,11 @@ class PublicID(ProvisioningModel):
         sp_uuid = yield self.get_sp()
         irs_uuid = yield ServiceProfile(sp_uuid).get_irs()
         defer.returnValue(irs_uuid)
+
+    @defer.inlineCallbacks
+    def get_irs_str(self):
+        irs_uuid = yield self.get_irs()
+        defer.returnValue(uuid_to_str(irs_uuid))
 
     @defer.inlineCallbacks
     def get_private_ids(self):


### PR DESCRIPTION
Should be mostly unsurprising - you've seen the design. The only new thing of note is that you can specify `?fast=true` to not return service profile and implicit registration set UUIDs, which can be an order of magnitude faster; I might not keep this option available permanently, but I'd at least like to have it for my perf testing, so  can compare the two options.

I've tested with 10k subscribers, confirming that I get 10,000 results on a GET and that it's slower and less CPU-intensive with `?chunk-proportion=16`.