### PR TITLE
[Reviewer: Rob] Add chunking to bulk retrieval API

### DIFF
--- a/docs/homestead_prov_api.md
+++ b/docs/homestead_prov_api.md
@@ -222,7 +222,7 @@ Make a GET to this URL to list the private IDs that can authenticate the public 
 * 200 if the public IDs exists, returned as JSON: `{ "private_ids": ["<private-id-1>", "<private-id-2>"] }`
 * 404 if the public ID does not exist.
 
-`/public/?excludeuuids=[true|false]&chunk-proportion=N`
+`/public/?excludeuuids=[true|false]&chunk-proportion=N&chunk=M`
 
 Make a GET to this URL to list all public IDs provisioned on the system.
 
@@ -236,6 +236,9 @@ Parameters:
     result in a faster response, but will be less well-paced (with a higher risk of disrupting
     service), and as Homestead handles more data at once, results in higher memory usage. The value
     of 256 has proved to work well in testing.
+* chunk (integer, default unset) - If set, this API only returns this chunk (i.e. a fraction of
+    the total subscriber base).  Chunks are 0-indexed, and so run from `0` to
+    `chunk-proportion - 1`.  If absent, this API returns all chunks.
 
 This API does a lot more work than the others, so it tends to be slower - as a rough guide, from
 testing on a 1-core VM:

--- a/docs/homestead_prov_api.md
+++ b/docs/homestead_prov_api.md
@@ -238,7 +238,9 @@ Parameters:
     of 256 has proved to work well in testing.
 * chunk (integer, default unset) - If set, this API only returns this chunk (i.e. a fraction of
     the total subscriber base).  Chunks are 0-indexed, and so run from `0` to
-    `chunk-proportion - 1`.  If absent, this API returns all chunks.
+    `chunk-proportion - 1` - e.g. if you have 10000 subscribers and set `chunk-proportion=1000`, a
+    query with `chunk=0` will return ~10 subscribers and a query with `chunk=1` will return another
+    ~10 subscribers.  If absent, this API returns all chunks.
 
 This API does a lot more work than the others, so it tends to be slower - as a rough guide, from
 testing on a 1-core VM:

--- a/src/metaswitch/crest/api/homestead/provisioning/handlers/public.py
+++ b/src/metaswitch/crest/api/homestead/provisioning/handlers/public.py
@@ -55,6 +55,8 @@ class AllPublicIDsHandler(BaseHandler):
     @defer.inlineCallbacks
     def get(self):
         num_chunks = int(self.get_argument("chunk-proportion", default=256))
+        chunk = self.get_argument("chunk", default="")
+        chunk = int(chunk) if chunk != "" else None
         fast = (self.get_argument("excludeuuids", default="false") == "true")
         _log.info("Retrieving all public IDs (broken into {} chunks)".format(num_chunks))
 
@@ -64,17 +66,22 @@ class AllPublicIDsHandler(BaseHandler):
 
         chunk_size = (max_token - min_token) / num_chunks
 
-        start = min_token
-        end = start + chunk_size
+        if chunk != None:
+            start = min_token + chunk * chunk_size
+            max_start = min([max_token, start + chunk_size])
+        else:
+            start = min_token
+            max_start = max_token
 
         # Query all subscribers, chunk-by-chunk, and stream it back to the
         # client
         first = True
         self.write('{"public_ids": [')
-        while start < max_token:
+        while start < max_start:
             if not first:
                 yield sleep(1)
 
+            end = min([max_token, start + chunk_size])
             result = yield PublicID.get_chunk(start=str(start), finish=str(end))
             for p in result:
                 sp = None
@@ -99,7 +106,6 @@ class AllPublicIDsHandler(BaseHandler):
 
             self.flush()
             start = end
-            end = min([max_token, start + chunk_size])
 
         self.write(']}')
 

--- a/src/metaswitch/crest/api/homestead/provisioning/handlers/public.py
+++ b/src/metaswitch/crest/api/homestead/provisioning/handlers/public.py
@@ -58,7 +58,6 @@ class AllPublicIDsHandler(BaseHandler):
         chunk = self.get_argument("chunk", default="")
         chunk = int(chunk) if chunk != "" else None
         fast = (self.get_argument("excludeuuids", default="false") == "true")
-        _log.info("Retrieving all public IDs (broken into {} chunks)".format(num_chunks))
 
         # Break the Cassandra ring down into chunks
         min_token = -2**63;
@@ -67,9 +66,11 @@ class AllPublicIDsHandler(BaseHandler):
         chunk_size = (max_token - min_token) / num_chunks
 
         if chunk != None:
+            _log.info("Retrieving public IDs (chunk {}/{})".format(chunk, num_chunks))
             start = min_token + chunk * chunk_size
             max_start = min([max_token, start + chunk_size])
         else:
+            _log.info("Retrieving all public IDs (broken into {} chunks)".format(num_chunks))
             start = min_token
             max_start = max_token
 


### PR DESCRIPTION
Rob,

Please can you review my enhancement to the bulk retrieval API to allow the chunk size to be specified by the client, rather than being timed by the server?

No UT because we don't have a good infrastructure on this part of the API, but live-tested.

Changes to clearwater-prov-tools to use this API will follow shortly.

Matt