### PR TITLE
[Reviewer: Ellie] Don't list deleted users

### DIFF
--- a/src/metaswitch/crest/api/homestead/provisioning/models.py
+++ b/src/metaswitch/crest/api/homestead/provisioning/models.py
@@ -418,7 +418,7 @@ class PublicID(ProvisioningModel):
                                                     finish=finish,
                                                     use_tokens=True,
                                                     count=10000000)
-        keys = [x.key for x in values]
+        keys = [x.key for x in values if len(x.columns) > 0]
         public_ids = [PublicID(x) for x in keys]
         _log.info("Queried tokens {} to {} - received {} results".format(start, finish, len(public_ids)))
         defer.returnValue(public_ids)


### PR DESCRIPTION
Fixes https://github.com/Metaswitch/crest/issues/249. Tested live:

```
[homestead-1]ubuntu@ec2-54-208-206-129:~$ /usr/share/clearwater/bin/create_user 3 rkd.cw-ngv.com hi
Public User ID sip:3@rkd.cw-ngv.com:
  Private User ID 3@rkd.cw-ngv.com:
    HA1 digest: a43efb3d960016725c3c86b0debfc1fd
  iFC:
    <?xml version="1.0" ?>
    <ServiceProfile>
    </ServiceProfile>
[homestead-1]ubuntu@ec2-54-208-206-129:~$ /usr/share/clearwater/bin/list_users
sip:3@rkd.cw-ngv.com
[homestead-1]ubuntu@ec2-54-208-206-129:~$ /usr/share/clearwater/bin/delete_user 3 rkd.cw-ngv.com
[homestead-1]ubuntu@ec2-54-208-206-129:~$ /usr/share/clearwater/bin/list_users
[homestead-1]ubuntu@ec2-54-208-206-129:~$
```

I haven't perf-tested - I think even if it had a perf impact, we'd want to merge it.