### PR TITLE
[No review required] Don't sleep unecessarily when listing all subscribers

### DIFF
--- a/src/metaswitch/crest/api/homestead/provisioning/handlers/public.py
+++ b/src/metaswitch/crest/api/homestead/provisioning/handlers/public.py
@@ -85,6 +85,11 @@ class AllPublicIDsHandler(BaseHandler):
                 # Write some data to prevent the request from being timed out by
                 # nginx. Use a space as whitespace is not significant in JSON.
                 self.write(' ')
+
+                # Sleep to avoid using too much CPU. Don't sleep on the first
+                # iteration as this makes the request take at least 1 second
+                # (which is bad for tools which query small subsections of the
+                # token space).
                 yield sleep(1)
 
             end = min([max_token, start + chunk_size])

--- a/src/metaswitch/crest/api/homestead/provisioning/handlers/public.py
+++ b/src/metaswitch/crest/api/homestead/provisioning/handlers/public.py
@@ -77,9 +77,16 @@ class AllPublicIDsHandler(BaseHandler):
         # Query all subscribers, chunk-by-chunk, and stream it back to the
         # client
         first_result = True
+        first_chunk = True
 
         self.write('{"public_ids": [')
         while start < max_start:
+            if not first_chunk:
+                # Write some data to prevent the request from being timed out by
+                # nginx. Use a space as whitespace is not significant in JSON.
+                self.write(' ')
+                yield sleep(1)
+
             end = min([max_token, start + chunk_size])
             result = yield PublicID.get_chunk(start=str(start), finish=str(end))
             for p in result:
@@ -103,15 +110,10 @@ class AllPublicIDsHandler(BaseHandler):
                 else:
                     self.write(json.dumps({"public_id": p.row_key_str}))
 
-            # Always write some data to prevent the request from being timed out
-            # by nginx. Use a space as whitespace is not significant in JSON.
-            self.write(' ')
-
             self.flush()
             start = end
 
-            # Sleep to avoid using too much CPU.
-            yield sleep(1)
+            first_chunk = False
 
         self.write(']}')
 


### PR DESCRIPTION
This is to avoid slowing down the `list_users` command. This adaptively changes the chunk-proprtion it requests, and sleeping for a second on each request dramatically slows this down when there are small numbers of subscribers. 

Effectively a revert of https://github.com/Metaswitch/crest/commit/8ba57744b93128b2be4dba992b5d7af14e788c80, but with some extra commenting.