### PR TITLE
Use process name to identify homer and homestead-prov

### DIFF
--- a/debian/homer.init.d
+++ b/debian/homer.init.d
@@ -47,7 +47,7 @@
 # PATH should only include /usr/* if it runs after the mountnfs.sh script
 PATH=/sbin:/usr/sbin:/bin:/usr/bin
 DESC=homer       # Introduce a short description here
-NAME=homer       # Introduce the short server's name here (not suitable for --name)
+NAME=homer       # Introduce the short server's name here
 DAEMON=/usr/share/clearwater/homer/env/bin/python # Introduce the server's location here
 DAEMON_ARGS="-m metaswitch.crest.main --worker-processes $(cat /proc/cpuinfo | grep processor | wc -l)"
 DAEMON_DIR=/usr/share/clearwater/homer/
@@ -101,10 +101,10 @@ do_start()
   #   0 if daemon has been started
   #   1 if daemon was already running
   #   2 if daemon could not be started
-  start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $DAEMON --test > /dev/null \
+  start-stop-daemon --start --quiet --pidfile $PIDFILE --name $NAME --exec $DAEMON --test > /dev/null \
     || return 1
   get_daemon_args
-  $namespace_prefix start-stop-daemon --start --quiet --chdir $DAEMON_DIR --exec $DAEMON -- $DAEMON_ARGS --background \
+  $namespace_prefix start-stop-daemon --start --quiet --chdir $DAEMON_DIR --name $NAME --exec $DAEMON -- $DAEMON_ARGS --background \
     || return 2
   # Add code here, if necessary, that waits for the process to be ready
   # to handle requests from services started subsequently which depend
@@ -117,7 +117,7 @@ do_start()
 do_run()
 {
   get_daemon_args
-  $namespace_prefix start-stop-daemon --start --quiet --chdir $DAEMON_DIR --exec $DAEMON -- $DAEMON_ARGS \
+  $namespace_prefix start-stop-daemon --start --quiet --chdir $DAEMON_DIR --name $NAME --exec $DAEMON -- $DAEMON_ARGS \
     || return 2
 }
 
@@ -134,7 +134,7 @@ do_stop()
   # Kill parent and children. Don't specify pidfile, or we'll kill only
   # the parent. This must be run while $DAEMON exists in the filesystem,
   # or start-stop-daemon will exit without doing anything.
-  start-stop-daemon --stop --quiet --retry=TERM/30/KILL/5 --exec $DAEMON
+  start-stop-daemon --stop --quiet --retry=TERM/30/KILL/5 --name $NAME --exec $DAEMON
   RETVAL="$?"
   [ "$RETVAL" = 2 ] && return 2
   # Many daemons don't delete their pidfiles when they exit.
@@ -154,7 +154,7 @@ do_abort()
   #   1 if daemon was already stopped
   #   2 if daemon could not be stopped
   #   other if a failure occurred
-  start-stop-daemon --stop --quiet --retry=USR1/5/TERM/30/KILL/5 --exec $DAEMON
+  start-stop-daemon --stop --quiet --retry=USR1/5/TERM/30/KILL/5 --name $NAME --exec $DAEMON
   RETVAL="$?"
   [ "$RETVAL" = 2 ] && return 2
   # Many daemons don't delete their pidfiles when they exit.

--- a/debian/homer.init.d
+++ b/debian/homer.init.d
@@ -47,7 +47,7 @@
 # PATH should only include /usr/* if it runs after the mountnfs.sh script
 PATH=/sbin:/usr/sbin:/bin:/usr/bin
 DESC=homer       # Introduce a short description here
-NAME=homer       # Introduce the short server's name here
+NAME=homer       # Introduce the short server's name here (must match PROCESS_NAME in local_settings.py)
 DAEMON=/usr/share/clearwater/homer/env/bin/python # Introduce the server's location here
 DAEMON_ARGS="-m metaswitch.crest.main --worker-processes $(cat /proc/cpuinfo | grep processor | wc -l)"
 DAEMON_DIR=/usr/share/clearwater/homer/

--- a/debian/homestead-prov.init.d
+++ b/debian/homestead-prov.init.d
@@ -47,7 +47,7 @@
 # PATH should only include /usr/* if it runs after the mountnfs.sh script
 PATH=/sbin:/usr/sbin:/bin:/usr/bin
 DESC=homestead-prov        # Introduce a short description here
-NAME=homestead-prov       # Introduce the short server's name here (not suitable for --name)
+NAME=homestead-prov       # Introduce the short server's name here
 DAEMON=/usr/share/clearwater/homestead/env/bin/python # Introduce the server's location here
 DAEMON_ARGS="-m metaswitch.crest.main --worker-processes 1"
 DAEMON_DIR=/usr/share/clearwater/homestead/
@@ -101,10 +101,10 @@ do_start()
   #   0 if daemon has been started
   #   1 if daemon was already running
   #   2 if daemon could not be started
-  start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $DAEMON --test > /dev/null \
+  start-stop-daemon --start --quiet --pidfile $PIDFILE --name $NAME --exec $DAEMON --test > /dev/null \
     || return 1
   get_daemon_args
-  $namespace_prefix start-stop-daemon --start --quiet --chdir $DAEMON_DIR --exec $DAEMON -- $DAEMON_ARGS --background \
+  $namespace_prefix start-stop-daemon --start --quiet --chdir $DAEMON_DIR --name $NAME --exec $DAEMON -- $DAEMON_ARGS --background \
     || return 2
   # Add code here, if necessary, that waits for the process to be ready
   # to handle requests from services started subsequently which depend
@@ -117,7 +117,7 @@ do_start()
 do_run()
 {
   get_daemon_args
-  $namespace_prefix start-stop-daemon --start --quiet --chdir $DAEMON_DIR --exec $DAEMON -- $DAEMON_ARGS \
+  $namespace_prefix start-stop-daemon --start --quiet --chdir $DAEMON_DIR --name $NAME --exec $DAEMON -- $DAEMON_ARGS \
     || return 2
 }
 
@@ -134,7 +134,7 @@ do_stop()
   # Kill parent and children. Don't specify pidfile, or we'll kill only
   # the parent. This must be run while $DAEMON exists in the filesystem,
   # or start-stop-daemon will exit without doing anything.
-  start-stop-daemon --stop --quiet --retry=TERM/30/KILL/5 --exec $DAEMON
+  start-stop-daemon --stop --quiet --retry=TERM/30/KILL/5 --name $NAME --exec $DAEMON
   RETVAL="$?"
   [ "$RETVAL" = 2 ] && return 2
   # Many daemons don't delete their pidfiles when they exit.
@@ -154,7 +154,7 @@ do_abort()
   #   1 if daemon was already stopped
   #   2 if daemon could not be stopped
   #   other if a failure occurred
-  start-stop-daemon --stop --quiet --retry=USR1/5/TERM/30/KILL/5 --exec $DAEMON
+  start-stop-daemon --stop --quiet --retry=USR1/5/TERM/30/KILL/5 --name $NAME --exec $DAEMON
   RETVAL="$?"
   [ "$RETVAL" = 2 ] && return 2
   # Many daemons don't delete their pidfiles when they exit.

--- a/debian/homestead-prov.init.d
+++ b/debian/homestead-prov.init.d
@@ -47,7 +47,7 @@
 # PATH should only include /usr/* if it runs after the mountnfs.sh script
 PATH=/sbin:/usr/sbin:/bin:/usr/bin
 DESC=homestead-prov        # Introduce a short description here
-NAME=homestead-prov       # Introduce the short server's name here
+NAME=homestead-prov       # Introduce the short server's name here (must match PROCESS_NAME in local_settings.py)
 DAEMON=/usr/share/clearwater/homestead/env/bin/python # Introduce the server's location here
 DAEMON_ARGS="-m metaswitch.crest.main --worker-processes 1"
 DAEMON_DIR=/usr/share/clearwater/homestead/

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,6 @@ setup(
     package_dir={'':'src'},
     package_data={'': ['*.xsd', '*.xml']},
     test_suite='metaswitch.crest.test',
-    install_requires=["pyzmq", "py-bcrypt", "cyclone==1.0", "cql", "lxml", "msgpack-python", "pure-sasl"],
+    install_requires=["pyzmq", "py-bcrypt", "cyclone==1.0", "cql", "lxml", "msgpack-python", "pure-sasl", "prctl"],
     tests_require=["pbr==1.6", "Mock"],
     )

--- a/src/metaswitch/crest/main.py
+++ b/src/metaswitch/crest/main.py
@@ -38,6 +38,7 @@
 import os
 import argparse
 import logging
+import prctl
 from sys import executable, exit
 from socket import AF_INET
 from fcntl import flock, LOCK_EX, LOCK_NB
@@ -115,6 +116,9 @@ def standalone():
     parser.add_argument("--shared-http-tcp-fd", default=None, type=int)
     parser.add_argument("--process-id", default=0, type=int)
     args = parser.parse_args()
+
+    # Set process name.
+    prctl.prctl(prctl.NAME, settings.PROCESS_NAME)
 
     # We don't initialize logging until we fork because we want each child to
     # have its own logging and it's awkward to reconfigure logging that is


### PR DESCRIPTION
Homer and homestead-prov's init.d script uses only the executable name to identify homer and homestead-prov functions.  This causes problems if another script (e.g. a bulk import) is being run using the homer or homestead-prov python interpreter at the same time as the daemon is started or stopped.  For starting, start-stop-daemon will refuse to start it, and for stopping it will kill the bulk import script.

The fix is to use the process name to identify the daemon processes, which we can set using the `prctl` system call.

This also has the advantage that the daemons appear as `homer` and `homestead-prov` in process management tools like `top`.