### PR TITLE
[Reviewer: Ellie] Run cqlsh in correct namespace

### DIFF
--- a/homestead.root/usr/share/clearwater/cassandra-schemas/homestead_provisioning.sh
+++ b/homestead.root/usr/share/clearwater/cassandra-schemas/homestead_provisioning.sh
@@ -21,10 +21,10 @@ USE homestead_provisioning;
 CREATE TABLE implicit_registration_sets (id uuid PRIMARY KEY, dummy text) WITH COMPACT STORAGE AND read_repair_chance = 1.0;
 CREATE TABLE service_profiles (id uuid PRIMARY KEY, irs text, initialfiltercriteria text) WITH COMPACT STORAGE AND read_repair_chance = 1.0;
 CREATE TABLE public (public_id text PRIMARY KEY, publicidentity text, service_profile text) WITH COMPACT STORAGE AND read_repair_chance = 1.0;
-CREATE TABLE private (private_id text PRIMARY KEY, digest_ha1 text, realm text) WITH COMPACT STORAGE AND read_repair_chance = 1.0;" | /usr/share/clearwater/bin/run-in-signaling-namespace cqlsh 
+CREATE TABLE private (private_id text PRIMARY KEY, digest_ha1 text, realm text) WITH COMPACT STORAGE AND read_repair_chance = 1.0;" | /usr/share/clearwater/bin/run-in-signaling-namespace cqlsh
 fi
 
-echo "USE homestead_provisioning; DESC TABLE private" | cqlsh | grep plaintext_password > /dev/null
+echo "USE homestead_provisioning; DESC TABLE private" | /usr/share/clearwater/bin/run-in-signaling-namespace cqlsh | grep plaintext_password > /dev/null
 if [ $? != 0 ]; then
   echo "USE homestead_provisioning;
   ALTER TABLE private ADD plaintext_password text;" | /usr/share/clearwater/bin/run-in-signaling-namespace cqlsh


### PR DESCRIPTION
Hi Ellie, 

This is a fix for some spurious error messages that are produced when run on a split network system.

I've tested this on our deployment, please could you review? It has a corresponding Homestead fix that I'll link once the PR is created.

Cheers,
Tom

