### PR TITLE
[Reviewer: Ellie] Bail out of schema scripts if Cassandra is not installed

### DIFF
--- a/homer.root/usr/share/clearwater/cassandra-schemas/homer.sh
+++ b/homer.root/usr/share/clearwater/cassandra-schemas/homer.sh
@@ -1,14 +1,8 @@
 #!/bin/bash
 
-cassandra_installed=$(dpkg-query -W -f='${Status}\n' cassandra | grep -q "install ok installed")
+. /usr/share/clearwater/cassandra-schemas/schema_utils.sh
 
-if [[ ! $cassandra_installed ]]
-then
-  echo "Cassandra is not installed yet, skipping schema addition for now"
-  exit 0
-fi
-
-. /usr/share/clearwater/cassandra-schemas/replication_string.sh
+quit_if_no_cassandra
 
 if [[ ! -e /var/lib/cassandra/data/homer ]];
 then

--- a/homer.root/usr/share/clearwater/cassandra-schemas/homer.sh
+++ b/homer.root/usr/share/clearwater/cassandra-schemas/homer.sh
@@ -1,4 +1,13 @@
 #!/bin/bash
+
+cassandra_installed=$(dpkg-query -W -f='${Status}\n' cassandra | grep -q "install ok installed")
+
+if [[ ! $cassandra_installed ]]
+then
+  echo "Cassandra is not installed yet, skipping schema addition for now"
+  exit 0
+fi
+
 . /usr/share/clearwater/cassandra-schemas/replication_string.sh
 
 if [[ ! -e /var/lib/cassandra/data/homer ]];

--- a/homer.root/usr/share/clearwater/cassandra-schemas/homer.sh
+++ b/homer.root/usr/share/clearwater/cassandra-schemas/homer.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-. /usr/share/clearwater/cassandra-schemas/schema_utils.sh
+. /usr/share/clearwater/cassandra_schema_utils.sh
 
 quit_if_no_cassandra
 

--- a/homer.root/usr/share/clearwater/infrastructure/scripts/homer
+++ b/homer.root/usr/share/clearwater/infrastructure/scripts/homer
@@ -52,8 +52,5 @@ then
   mv /tmp/local_settings.py.$$ /usr/share/clearwater/homer/local_settings.py
 fi
 
-# Create Cassandra schema if Cassandra is installed.
-if dpkg-query -W -f='${Status}' cassandra | grep -iq installed
-then
-  /usr/share/clearwater/cassandra-schemas/homer.sh || /bin/true
-fi
+# Create Cassandra schema
+/usr/share/clearwater/cassandra-schemas/homer.sh || /bin/true

--- a/homestead.root/usr/share/clearwater/cassandra-schemas/homestead_provisioning.sh
+++ b/homestead.root/usr/share/clearwater/cassandra-schemas/homestead_provisioning.sh
@@ -1,4 +1,13 @@
 #! /bin/bash
+
+cassandra_installed=$(dpkg-query -W -f='${Status}\n' cassandra | grep -q "install ok installed")
+
+if [[ ! $cassandra_installed ]]
+then
+  echo "Cassandra is not installed yet, skipping schema addition for now"
+  exit 0
+fi
+
 . /usr/share/clearwater/cassandra-schemas/replication_string.sh
 
 if [[ ! -e /var/lib/cassandra/data/homestead_provisioning ]];

--- a/homestead.root/usr/share/clearwater/cassandra-schemas/homestead_provisioning.sh
+++ b/homestead.root/usr/share/clearwater/cassandra-schemas/homestead_provisioning.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-. /usr/share/clearwater/cassandra-schemas/schema_utils.sh
+. /usr/share/clearwater/cassandra_schema_utils.sh
 
 quit_if_no_cassandra
 

--- a/homestead.root/usr/share/clearwater/cassandra-schemas/homestead_provisioning.sh
+++ b/homestead.root/usr/share/clearwater/cassandra-schemas/homestead_provisioning.sh
@@ -1,14 +1,8 @@
 #! /bin/bash
 
-cassandra_installed=$(dpkg-query -W -f='${Status}\n' cassandra | grep -q "install ok installed")
+. /usr/share/clearwater/cassandra-schemas/schema_utils.sh
 
-if [[ ! $cassandra_installed ]]
-then
-  echo "Cassandra is not installed yet, skipping schema addition for now"
-  exit 0
-fi
-
-. /usr/share/clearwater/cassandra-schemas/replication_string.sh
+quit_if_no_cassandra
 
 if [[ ! -e /var/lib/cassandra/data/homestead_provisioning ]];
 then

--- a/homestead.root/usr/share/clearwater/infrastructure/scripts/homestead-prov
+++ b/homestead.root/usr/share/clearwater/infrastructure/scripts/homestead-prov
@@ -33,8 +33,5 @@ then
   mv /tmp/local_settings.py.$$ /usr/share/clearwater/homestead/local_settings.py
 fi
 
-# Create Cassandra schema if Cassandra is installed.
-if dpkg-query -W -f='${Status}' cassandra | grep -iq installed
-then
-  /usr/share/clearwater/cassandra-schemas/homestead_provisioning.sh || /bin/true
-fi
+# Create Cassandra schema
+/usr/share/clearwater/cassandra-schemas/homestead_provisioning.sh || /bin/true


### PR DESCRIPTION
As suggested in https://github.com/Metaswitch/homestead/issues/269, moves the "is Cassandra installed" check into the schema scripts.

* I've changed the check to be more explicit about dpkg states - there's a half-installed state that I was worried the old grep might catch
* I've read the docs to convince myself that we'll never end up in a state where we don't get the schemas installed - although a package might be unpacked before its dependencies are configured, it will always be configured after its dependencies are configured, so when homer.postinst runs and calls `/usr/share/clearwater/cassandra-schemas/homer.sh`, the dpkg-query check must return true at that point and the rest of the code will run
* Just in case this does cause issues, I've added a log so we can detect problems from install output

I'm intending to port this to the other Cassandra-using repositories (homestead, memento, etc.) and test by spinning up a minimal clustered deployment and an all-in-one deployment, and checking they both get their schemas.

I wondered whether to revert the `|| /bin/true` added in https://github.com/Metaswitch/crest/commit/4c1000bf03a568f652223be4c7fbc217d9a2bb90 but I think that would introduce a cluster manager timing window (if it restarts Cassandra just as this package is configuring)