### PR TITLE
[Reviewer Matt] Monotonic

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -27,6 +27,9 @@ defined in `.gitmodules`:
 
 Pre-requisites
 ==============
+
+Crest relies on APT packages available from the Project Clearwater repository server. To configure your build environment to install these packages, follow the instructions at [ReadTheDocs](http://clearwater.readthedocs.org/en/latest/Manual_Install.html#configure-the-apt-software-sources).
+
 1. Pip and virtualenv
 
     ```

--- a/setup_crest.py
+++ b/setup_crest.py
@@ -1,4 +1,4 @@
-# @file setup.py
+# @file setup_crest.py
 #
 # Project Clearwater - IMS in the Cloud
 # Copyright (C) 2013  Metaswitch Networks Ltd

--- a/setup_crest.py
+++ b/setup_crest.py
@@ -57,7 +57,7 @@ setup(
     packages=find_packages('src', include=['metaswitch', 'metaswitch.crest', 'metaswitch.crest.*']),
     package_dir={'':'src'},
     test_suite='metaswitch.crest.test',
-    install_requires=["pyzmq==15.2", "py-bcrypt", "cyclone==1.0", "cql==1.4.0", "lxml", "msgpack-python==0.4.7", "pure-sasl", "prctl"],
+    install_requires=["pyzmq==15.2", "py-bcrypt", "cyclone==1.0", "cql==1.4.0", "lxml", "msgpack-python==0.4.7", "pure-sasl", "prctl", "monotonic==0.6"],
     tests_require=["pbr==1.6", "Mock"],
     options={"build": {"build_base": "build-crest"}},
     )

--- a/setup_homer.py
+++ b/setup_homer.py
@@ -1,4 +1,4 @@
-# @file setup.py
+# @file setup_homer.py
 #
 # Project Clearwater - IMS in the Cloud
 # Copyright (C) 2013  Metaswitch Networks Ltd

--- a/setup_homestead_prov.py
+++ b/setup_homestead_prov.py
@@ -1,4 +1,4 @@
-# @file setup.py
+# @file setup_homestead_prov.py
 #
 # Project Clearwater - IMS in the Cloud
 # Copyright (C) 2013  Metaswitch Networks Ltd

--- a/src/metaswitch/crest/api/base.py
+++ b/src/metaswitch/crest/api/base.py
@@ -47,7 +47,7 @@ from telephus.cassandra.ttypes import TimedOutException as CassandraTimeout
 from metaswitch.common import utils
 from metaswitch.crest import settings
 from metaswitch.crest.api.statistics import Accumulator, Counter
-from metaswitch.common.monotonic_time import monotonic_time
+from monotonic import monotonic
 from metaswitch.crest.api.DeferTimeout import TimeoutError
 from metaswitch.crest.api.exceptions import HSSOverloaded, HSSConnectionLost, HSSStillConnecting, UserNotIdentifiable, UserNotAuthorized
 from metaswitch.crest.api.lastvaluecache import LastValueCache
@@ -88,7 +88,7 @@ class LeakyBucket:
         self.max_size = max_size
         self.tokens = max_size
         self.rate = rate
-        self.replenish_time = monotonic_time()
+        self.replenish_time = monotonic()
 
     def get_token(self):
         self.replenish_bucket()
@@ -105,7 +105,7 @@ class LeakyBucket:
         self.max_size = new_max_size
 
     def replenish_bucket(self):
-        replenish_time = monotonic_time()
+        replenish_time = monotonic()
         self.tokens += self.rate * (replenish_time - self.replenish_time)
         self.replenish_time = replenish_time
         if self.tokens > self.max_size:
@@ -256,7 +256,7 @@ class BaseHandler(cyclone.web.RequestHandler):
         incoming_requests.increment()
 
         # timestamp the request
-        self._start = monotonic_time()
+        self._start = monotonic()
         _log.info("Received request from %s - %s %s://%s%s" %
                    (self.request.remote_ip, self.request.method, self.request.protocol, self.request.host, self.request.uri))
         if not loadmonitor.admit_request():
@@ -274,7 +274,7 @@ class BaseHandler(cyclone.web.RequestHandler):
                     self.request.uri))
 
         loadmonitor.request_complete()
-        latency = monotonic_time() - self._start
+        latency = monotonic() - self._start
         if self.should_count_requests_in_latency():
             loadmonitor.update_latency(latency)
 
@@ -440,7 +440,7 @@ class BaseHandler(cyclone.web.RequestHandler):
         MAX_REQUEST_TIME = 0.5
 
         def wrapper(handler, *pos_args, **kwd_args):
-            if monotonic_time() - handler._start > MAX_REQUEST_TIME:
+            if monotonic() - handler._start > MAX_REQUEST_TIME:
                 handler.send_error(503, "Request too old")
             else:
                 return func(handler, *pos_args, **kwd_args)

--- a/src/metaswitch/crest/api/statistics.py
+++ b/src/metaswitch/crest/api/statistics.py
@@ -35,7 +35,7 @@
 import logging
 import abc
 import base
-from metaswitch.common.monotonic_time import monotonic_time
+from monotonic import monotonic
 
 # Collect stats every 5 seconds
 STATS_PERIOD = 5
@@ -51,7 +51,7 @@ class Collector(object):
 
     def __init__(self, stat_name):
         self.stat_name = stat_name
-        self.start_time = monotonic_time()
+        self.start_time = monotonic()
 
     @abc.abstractmethod
     def refresh(self):
@@ -85,7 +85,7 @@ class Counter(Collector):
         self.refresh()
 
     def refresh(self):
-        time_difference = monotonic_time() - self.start_time
+        time_difference = monotonic() - self.start_time
 
         if time_difference > STATS_PERIOD:
             base.zmq.report([self.current], self.stat_name)
@@ -93,7 +93,7 @@ class Counter(Collector):
 
     def reset(self):
         self.current = 0
-        self.start_time = monotonic_time()
+        self.start_time = monotonic()
 
 class Accumulator(Collector):
     """
@@ -123,7 +123,7 @@ class Accumulator(Collector):
         self.refresh()
 
     def refresh(self):
-        time_difference = monotonic_time() - self.start_time
+        time_difference = monotonic() - self.start_time
         mean = 0
         variance = 0
 
@@ -143,4 +143,4 @@ class Accumulator(Collector):
         self.sigma_squared = 0
         self.lwm = 0
         self.hwm = 0
-        self.start_time = monotonic_time()
+        self.start_time = monotonic()

--- a/src/metaswitch/crest/test/api/base.py
+++ b/src/metaswitch/crest/test/api/base.py
@@ -41,7 +41,7 @@ import uuid
 from cyclone.web import HTTPError
 from twisted.python.failure import Failure
 from metaswitch.crest.api import base
-from metaswitch.common.monotonic_time import monotonic_time
+from monotonic import monotonic
 
 from mock import patch, MagicMock
 
@@ -132,7 +132,7 @@ class TestBaseHandler(unittest.TestCase):
     def test_check_request_age_decorator(self):
         """ Test the check_request_age decorator with a recent request"""
         # Set the start time of the request to now
-        self._start = monotonic_time()
+        self._start = monotonic()
         # Call a mock function with the decorator - as the request is recent, the
         # underlying function should be called as normal
         decorator = self.handler.check_request_age
@@ -145,7 +145,7 @@ class TestBaseHandler(unittest.TestCase):
         """ Test the check_request_age decorator with an old request"""
         self.send_error = MagicMock()
         # Ensure that the request is too old
-        self._start = monotonic_time() - 1000
+        self._start = monotonic() - 1000
         # Call a mock function with the decorator - as the request is old, the decorator
         # should send a 503 error and the underlying function should not be called.
         decorator = self.handler.check_request_age


### PR DESCRIPTION
Use the PyPI mononotonic module.
Instead of using our own code to get monotonic time, use the publicly
available monotonic module to do so.

This follows on from the changes in https://github.com/Metaswitch/python-common/pull/48.