### PR TITLE
[Reviewer: Rob] Remove (unused) preferred flag from AV

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -146,7 +146,7 @@ If you haven't already set up Homestead, you will also need to install the `home
 
     echo "CREATE KEYSPACE homestead_cache WITH REPLICATION =  {'class': 'SimpleStrategy', 'replication_factor': 2};
           USE homestead_cache;
-          CREATE TABLE impi (private_id text PRIMARY KEY, digest_ha1 text, digest_realm text, digest_qop text, known_preferred boolean) WITH COMPACT STORAGE AND read_repair_chance = 1.0;
+          CREATE TABLE impi (private_id text PRIMARY KEY, digest_ha1 text, digest_realm text, digest_qop text) WITH COMPACT STORAGE AND read_repair_chance = 1.0;
           CREATE TABLE impu (public_id text PRIMARY KEY, ims_subscription_xml text, is_registered Boolean, primary_ccf text, secondary_ccf text, primary_ecf text, secondary_ecf text) WITH COMPACT STORAGE AND read_repair_chance = 1.0;
           CREATE TABLE impi_mapping (private_id text PRIMARY KEY, unused text) WITH COMPACT STORAGE AND read_repair_chance = 1.0; | cqlsh
 

--- a/src/metaswitch/homestead_prov/auth_vectors.py
+++ b/src/metaswitch/homestead_prov/auth_vectors.py
@@ -38,19 +38,11 @@ class AuthVector(object):
         raise NotImplementedError
 
 class DigestAuthVector(AuthVector):
-    def __init__(self, ha1, realm, qop, preferred):
+    def __init__(self, ha1, realm, qop):
         self.type = authtypes.SIP_DIGEST
         self.ha1 = ha1
         self.realm = realm or settings.SIP_DIGEST_REALM
         self.qop = qop or "auth"
-
-        # The "preferred" attribute relates to caching - if we receive
-        # a request specifically for the SIP Digest and cache it, and
-        # then get a request which doesn't specify the authentication
-        # type, we shouldn't respond from cache. Instead, we should
-        # query the HSS, because it may be configured to default to
-        # AKA rather than Digest (i.e. SIP Digest is not "preferred").
-        self.preferred = preferred
 
     def to_json(self):
         return {"digest": {"ha1": self.ha1, "realm": self.realm, "qop": self.qop}}

--- a/src/metaswitch/homestead_prov/cache/cache.py
+++ b/src/metaswitch/homestead_prov/cache/cache.py
@@ -66,9 +66,9 @@ class Cache(object):
         _log.debug("Fetched digest for private ID '%s' from cache: %s" %
                    (private_id, av))
         if av:
-            ha1, realm, qop, preferred = av
-            if preferred or (authtype == authtypes.SIP_DIGEST):
-                defer.returnValue(DigestAuthVector(ha1, realm, qop, preferred))
+            ha1, realm, qop = av
+            if authtype == authtypes.SIP_DIGEST:
+                defer.returnValue(DigestAuthVector(ha1, realm, qop))
         # Subscriber not found, return None
         defer.returnValue(None)
 
@@ -86,7 +86,6 @@ class Cache(object):
         yield IMPI(private_id).put_av(auth_vector.ha1,
                                       auth_vector.realm,
                                       auth_vector.qop,
-                                      auth_vector.preferred,
                                       ttl=ttl,
                                       timestamp=timestamp)
 

--- a/src/metaswitch/homestead_prov/provisioning/models.py
+++ b/src/metaswitch/homestead_prov/provisioning/models.py
@@ -308,7 +308,7 @@ class PrivateID(ProvisioningModel):
 
         yield self.modify_columns(columns)
         yield self._cache.put_av(self.row_key,
-                                 DigestAuthVector(digest, realm, None, True),
+                                 DigestAuthVector(digest, realm, None),
                                  self._cache.generate_timestamp())
 
     @defer.inlineCallbacks
@@ -358,7 +358,7 @@ class PrivateID(ProvisioningModel):
         # update happens after the delete.
         yield self._cache.delete_private_id(self.row_key, timestamp - 1000)
         yield self._cache.put_av(self.row_key,
-                                 DigestAuthVector(digest, realm, None, True),
+                                 DigestAuthVector(digest, realm, None),
                                  self._cache.generate_timestamp())
         for pub_id in public_ids:
             yield self._cache.put_associated_public_id(self.row_key,


### PR DESCRIPTION
Rob,

Please can you review this change to remove the unused preferred flag from AV (equivalent to https://github.com/Metaswitch/homestead/pull/310, but for crest)?

I've run UTs.

Matt