### PR TITLE
Switch from Python version of bracket_ipv6_address to C++ version

### DIFF
--- a/homer.root/usr/share/clearwater/bin/poll_homer.sh
+++ b/homer.root/usr/share/clearwater/bin/poll_homer.sh
@@ -52,7 +52,7 @@ rm -f /tmp/poll-homer.sh.stderr.$$ /tmp/poll-homer.sh.stdout.$$
 
 if [ ! -z $signaling_namespace ] ; then
   # For the signalling address, wrap IPv6 addresses in square brackets. This should be the local_ip.
-  http_ip=$(/usr/share/clearwater/bin/bracket_ipv6_address.py $local_ip)
+  http_ip=$(/usr/share/clearwater/bin/bracket-ipv6-address $local_ip)
   /usr/share/clearwater/bin/poll-http $http_ip:7888
   rc_sig=$?
 


### PR DESCRIPTION
Same as https://github.com/Metaswitch/clearwater-infrastructure/pull/332, but for this repo.