### PR TITLE
[Reviewer Ellie] Enhance ping to do a Cassandra request

### DIFF
--- a/src/metaswitch/crest/api/ping.py
+++ b/src/metaswitch/crest/api/ping.py
@@ -50,7 +50,11 @@ class PingHandler(RequestHandler):
         gets = (client.get(key='ping', column_family='ping')
                 for client in clients)
 
-        # We don't care about the result, just whether it returns
-        # in a timely fashion.
-        yield defer.gatherResults(gets, consumeErrors=True)
+        try:
+            yield defer.gatherResults(gets)
+        except:
+            # We don't care about the result, just whether it returns
+            # in a timely fashion. Writing a log would be spammy.
+            pass
+
         self.finish("OK")


### PR DESCRIPTION
This aims to fix issue #283 by restarting Homer if Cassandra requests aren't getting responses.

I've tested this live on an aio image, both using curl to check the behaviour of the poll, and watching monit summary to see that monit does the right thing.