### PR TITLE
[Reviewer: Ellie] Fix up tests.

### DIFF
--- a/src/metaswitch/crest/api/ping.py
+++ b/src/metaswitch/crest/api/ping.py
@@ -51,8 +51,10 @@ class PingHandler(RequestHandler):
                 for client in clients)
 
         try:
-            yield defer.gatherResults(gets)
-        except:
+            # Use a DeferredList rather than gatherResults to wait
+            # for all of the clients to fail or succeed.
+            yield defer.DeferredList(gets, consume_errors=True)
+        except Exception:
             # We don't care about the result, just whether it returns
             # in a timely fashion. Writing a log would be spammy.
             pass


### PR DESCRIPTION
I forgot that `make test` doesn't run all the tests. This fixes up coverage, and some test bugs.

- Make sure to use the right mocks for the right job.
- Use a DeferredList rather than gatherResults to ensure that all
requests complete.
- Use the 'fail' convenience method to fail.