### PR TITLE
[Reviewer: Rob] Don't consume all errors

### DIFF
--- a/src/metaswitch/crest/api/ping.py
+++ b/src/metaswitch/crest/api/ping.py
@@ -38,23 +38,26 @@ from twisted.internet import defer
 from .passthrough import PassthroughHandler
 
 
+# This class responds to pings - we use it to confirm that Homer/Homestead-prov
+# are still responsive and functional
 class PingHandler(RequestHandler):
     @defer.inlineCallbacks
     def get(self):
-        # We've seen cases where the telephus fails to connect to Cassandra,
-        # and requests sit on the queue forever without being processed.
-        # Catch this error case by making a request here on each Cassandra
-        # connection.
+        # Attempt to connect to Cassandra (by asking for a non-existent key).
+        # We need this check as we've seen cases where telephus fails to
+        # connect to Cassandra, and requests sit on the queue forever without
+        # being processed.
         factories = PassthroughHandler.cass_factories.values()
         clients = (CassandraClient(factory) for factory in factories)
         gets = (client.get(key='ping', column_family='ping')
                 for client in clients)
 
+        # If Cassandra is up, it will throw an expection (because we're asking
+        # for a nonexistent key). That's fine - it proves Cassandra is up and
+        # we have a connection to it. If Cassandra is down, this call will
+        # never return and Monit will time it out and kill the process for
+        # unresponsiveness.
         try:
-            # Use a DeferredList rather than gatherResults to wait
-            # for all of the clients to fail or succeed. Don't consume errors -
-            # this masks the case when cassandra is down. The except below
-            # deals with us asking for a non existent key
             yield defer.DeferredList(gets)
         except Exception:
             # We don't care about the result, just whether it returns

--- a/src/metaswitch/crest/api/ping.py
+++ b/src/metaswitch/crest/api/ping.py
@@ -52,8 +52,10 @@ class PingHandler(RequestHandler):
 
         try:
             # Use a DeferredList rather than gatherResults to wait
-            # for all of the clients to fail or succeed.
-            yield defer.DeferredList(gets, consume_errors=True)
+            # for all of the clients to fail or succeed. Don't consume errors -
+            # this masks the case when cassandra is down. The except below
+            # deals with us asking for a non existent key
+            yield defer.DeferredList(gets)
         except Exception:
             # We don't care about the result, just whether it returns
             # in a timely fashion. Writing a log would be spammy.


### PR DESCRIPTION
This tweaks the change made in #287 so that it doesn't consume all errors (which masks the case when Cassandra is down).

Fixes #283 

Testing has been on a Homer node and I've checked that killing cassandra causes monit to restart Homer and starting Homer without a running cassandra process causes monit to restart Homer