### PR TITLE
[Reviewer: Ellie] Configure logging via user_settings

### DIFF
--- a/debian/homer.init.d
+++ b/debian/homer.init.d
@@ -72,6 +72,8 @@ SCRIPTNAME=/etc/init.d/$NAME
 #
 get_settings()
 {
+  log_level=2
+
   . /etc/clearwater/config
 
   if [ ! -z "$signaling_namespace" ]
@@ -89,7 +91,7 @@ get_daemon_args()
   # Get the settings
   get_settings
 
-  DAEMON_ARGS="$DAEMON_ARGS $signaling_opt"
+  DAEMON_ARGS="$DAEMON_ARGS $signaling_opt --log-level $log_level"
 
   export CREST_SETTINGS=/usr/share/clearwater/homer/local_settings.py
   export PYTHONPATH=/usr/share/clearwater/homer/python/packages

--- a/debian/homestead-prov.init.d
+++ b/debian/homestead-prov.init.d
@@ -72,6 +72,8 @@ SCRIPTNAME=/etc/init.d/$NAME
 #
 get_settings()
 {
+  log_level=2
+
   . /etc/clearwater/config
 
   if [ ! -z "$signaling_namespace" ]
@@ -89,7 +91,7 @@ get_daemon_args()
   # Get the settings
   get_settings
 
-  DAEMON_ARGS="$DAEMON_ARGS $signaling_opt"
+  DAEMON_ARGS="$DAEMON_ARGS $signaling_opt --log-level $log_level"
 
   export CREST_SETTINGS=/usr/share/clearwater/homestead/local_settings.py
   export PYTHONPATH=/usr/share/clearwater/homestead/python/packages

--- a/src/metaswitch/crest/main.py
+++ b/src/metaswitch/crest/main.py
@@ -142,17 +142,12 @@ def standalone():
     # Setup logging
     syslog.openlog(settings.LOG_FILE_PREFIX, syslog.LOG_PID)
 
-    # Map from Clearwater log levels to Python. Python doesn't have status or
-    # verbose levels.
-    LOG_LEVELS = {0: logging.ERROR,
-                  1: logging.WARNING,
-                  2: logging.INFO,
-                  3: logging.INFO,
-                  4: logging.DEBUG,
-                  5: logging.DEBUG}
-    if args.log_level > 5 or args.log_level < 0:
-        args.log_level = 2
-    logging_config.configure_logging(LOG_LEVELS[args.log_level], settings.LOGS_DIR, settings.LOG_FILE_PREFIX, args.process_id)
+    logging_config.configure_logging(
+            utils.map_clearwater_log_level(args.log_level),
+            settings.LOGS_DIR,
+            settings.LOG_FILE_PREFIX,
+            args.process_id)
+
     twisted.python.log.addObserver(on_twisted_log)
 
     pdlogs.CREST_STARTING.log()

--- a/src/metaswitch/crest/main.py
+++ b/src/metaswitch/crest/main.py
@@ -116,6 +116,7 @@ def standalone():
     parser.add_argument("--worker-processes", default=1, type=int)
     parser.add_argument("--shared-http-tcp-fd", default=None, type=int)
     parser.add_argument("--process-id", default=0, type=int)
+    parser.add_argument("--log-level", default=2, type=int)
     args = parser.parse_args()
 
     # Set process name.
@@ -140,7 +141,18 @@ def standalone():
 
     # Setup logging
     syslog.openlog(settings.LOG_FILE_PREFIX, syslog.LOG_PID)
-    logging_config.configure_logging(settings.LOG_LEVEL, settings.LOGS_DIR, settings.LOG_FILE_PREFIX, args.process_id)
+
+    # Map from Clearwater log levels to Python. Python doesn't have status or
+    # verbose levels.
+    LOG_LEVELS = {0: logging.ERROR,
+                  1: logging.WARNING,
+                  2: logging.INFO,
+                  3: logging.INFO,
+                  4: logging.DEBUG,
+                  5: logging.DEBUG}
+    if args.log_level > 5 or args.log_level < 0:
+        args.log_level = 2
+    logging_config.configure_logging(LOG_LEVELS[args.log_level], settings.LOGS_DIR, settings.LOG_FILE_PREFIX, args.process_id)
     twisted.python.log.addObserver(on_twisted_log)
 
     pdlogs.CREST_STARTING.log()

--- a/src/metaswitch/crest/settings.py
+++ b/src/metaswitch/crest/settings.py
@@ -70,7 +70,6 @@ CERTS_DIR = os.path.join(PROJECT_DIR, "certificates")
 LOG_FILE_PREFIX = "homer"
 LOG_FILE_MAX_BYTES = 10000000
 LOG_BACKUP_COUNT = 10
-LOG_LEVEL = logging.INFO
 PID_FILE = os.path.join(PROJECT_DIR, "server.pid")
 
 # Tornado cookie encryption key.  Tornado instances that share this key will


### PR DESCRIPTION
Pass the log level in via the command line so it's configured from /etc/clearwater rather than local_settings.py

This fixes issue #290 and issue #272.

I've tested this on a homer node, configuring the log level via `/etc/clearwater/user_settings`, and then running `sudo monit restart homer_process`.

After this, I need to fix up the docs which claim all sorts of things - e.g. that log_level 1 is error logs only (it's warnings as well), or how you log from crest, which just doesn't work at all.