### PR TITLE
[Reviewer: RKD] Move all provisioning scripts to homestead-prov-cassandra

### DIFF
--- a/debian/homer-cassandra.install
+++ b/debian/homer-cassandra.install
@@ -1,3 +1,1 @@
 homer-cassandra.root/* /
-src/metaswitch/crest/tools /usr/share/clearwater/crest/src/metaswitch/crest/
-src/metaswitch/crest/tools/sstable_provisioning/* /usr/share/clearwater/crest/tools/sstable_provisioning

--- a/src/metaswitch/crest/tools/sstable_provisioning/README.md
+++ b/src/metaswitch/crest/tools/sstable_provisioning/README.md
@@ -2,11 +2,11 @@
 
 These scripts will enable you to create a collection of sstables (Cassandra raw data) and then inject those tables directly into your Cassandra cluster.
 
-All the scripts assume they are being run on a node running the Homer or Homestead database and that the Cassandra database clusters are correctly configured and balanced.
+All the scripts assume they are being run on a node running the Homestead database and that the Cassandra database clusters are correctly configured and balanced.
 
 ## Pre-requisites
 
-* The bulk provisioning binaries - automatically installed on Homer/Homestead database nodes to `/usr/share/clearwater/crest/tools/sstable_provisioning`
+* The bulk provisioning binaries - automatically installed on Homestead database nodes to `/usr/share/clearwater/crest/tools/sstable_provisioning`
 * A users CSV file - In the format output by [`bulk_autocomplete.py`](https://github.com/Metaswitch/crest/blob/dev/docs/Bulk-Provisioning%20Numbers.md)
 
 ## Disk space
@@ -29,7 +29,7 @@ The sstables can be created either from CSV files describing each subscriber or 
 
 In the below, `<csvfilename>` refers to the filename of the users CSV file **without the suffix**, e.g. if the file were called `users.csv` then `<csvfilename>` would be `users`.
 
-Use the python executable bundled with Homer/Homestead to prepare the CSV file by hashing the password and adding the simservs/ifc bodies.
+Use the python executable bundled with Homestead to prepare the CSV file by hashing the password and adding the simservs/ifc bodies.
 
     sudo /usr/share/clearwater/crest/env/bin/python ./prepare_csv.py <csvfilename>.csv
 


### PR DESCRIPTION
Stop `homer-cassandra` owning the paths `/usr/share/clearwater/crest/src/metaswitch/crest/` and `/usr/share/clearwater/crest/tools/sstable_provisioning`.

This means that when we have both homestead-prov-cassandra and homer-cassandra installed, we no longer have problems where both of those packages try to own the paths above.

I've made some changes to the sstable documentation, where I removed all references to homer, but I don't know about sstable so they might be wrong.