### PR TITLE
Reviewer EM: Use pidfile in status call

### DIFF
--- a/debian/homer.init.d
+++ b/debian/homer.init.d
@@ -186,7 +186,7 @@ case "$1" in
     esac
     ;;
   status)
-    status_of_proc "$DAEMON" "$NAME" && exit 0 || exit $?
+    status_of_proc -p "$PIDFILE" "$DAEMON" "$NAME" && exit 0 || exit $?
     ;;
   restart|force-reload)
     log_daemon_msg "Restarting $DESC" "$NAME"

--- a/debian/homestead-prov.init.d
+++ b/debian/homestead-prov.init.d
@@ -186,7 +186,7 @@ case "$1" in
     esac
     ;;
   status)
-    status_of_proc "$DAEMON" "$NAME" && exit 0 || exit $?
+    status_of_proc -p "$PIDFILE" "$DAEMON" "$NAME" && exit 0 || exit $?
     ;;
   restart|force-reload)
     log_daemon_msg "Restarting $DESC" "$NAME"


### PR DESCRIPTION
This is needed because currently if only one of homer or homestead-prov are running, `sudo service [homer|homestead-prov] status` always reports that bother processes are running. This is because $NAME is just used for the output, and there's no way to distinguish between them.