### PR TITLE
[Reviewer: Ellie] Make the ping handler also check homestead's connection to cassandra

### DIFF
--- a/src/metaswitch/crest/test/api/ping.py
+++ b/src/metaswitch/crest/test/api/ping.py
@@ -66,16 +66,11 @@ class TestPingHandler(unittest.TestCase):
                           mock_passthrough_handler,
                           mock_deferred_list):
         """Test that the ping runs to completion in the mainline."""
-        # This test is designed to catch regressions where a change to
-        # the PassthroughHandler or library APIs would stop the ping
-        # from functioning in the mainline.
-        #
+
         # Make sure there is at least one (fake) connection to Cassandra, to
         # exercise the main logic, and check that only real methods are
         # called.
-        mock_passthrough_handler.cass_factories.values.return_value = [
-            telephus.protocol.ManagedCassandraClientFactory(),
-        ]
+        ping.PingHandler.register_cass_factory(telephus.protocol.ManagedCassandraClientFactory())
         mock_deferred_list.return_value = fail(Exception())
 
         # Insert a mock so that we can extract the value that finish

--- a/src/metaswitch/homer/__init__.py
+++ b/src/metaswitch/homer/__init__.py
@@ -37,6 +37,7 @@ from twisted.internet import reactor
 from telephus.protocol import ManagedCassandraClientFactory
 
 from metaswitch.crest.api.passthrough import PassthroughHandler
+from metaswitch.crest.api.ping import PingHandler
 from metaswitch.crest import settings
 from metaswitch.homer import routes
 
@@ -50,3 +51,4 @@ def initialize(application):
                        settings.CASS_PORT,
                        factory)
     PassthroughHandler.add_cass_factory("homer", factory)
+    PingHandler.register_cass_factory(factory)

--- a/src/metaswitch/homestead_prov/__init__.py
+++ b/src/metaswitch/homestead_prov/__init__.py
@@ -40,6 +40,7 @@ from .provisioning.handlers.public import PublicIDServiceProfileHandler, PublicI
 
 from .cache.db import CacheModel
 from .provisioning.models import PrivateID, IRS, ServiceProfile, PublicID, ProvisioningModel
+from metaswitch.crest.api.ping import PingHandler
 
 # Regex that matches any path element (covers anything that isn't a slash).
 ANY = '([^/]+)'
@@ -142,6 +143,11 @@ def initialize(application):
     application.cache = Cache()
     ProvisioningModel.register_cache(application.cache)
 
-    # Connect to the cache and provisioning databases.
+    # Connect to the cache and provisioning databases. Register the cassandra
+    # factories with the PingHandler so that connectivity to cassandra is
+    # checked when crest is pinged.
     ProvisioningModel.start_connection()
+    PingHandler.register_cass_factory(ProvisioningModel.get_cass_factory())
+
     CacheModel.start_connection()
+    PingHandler.register_cass_factory(CacheModel.get_cass_factory())

--- a/src/metaswitch/homestead_prov/cassandra.py
+++ b/src/metaswitch/homestead_prov/cassandra.py
@@ -44,9 +44,9 @@ class CassandraConnection(object):
     def __init__(self, keyspace):
         self._keyspace = keyspace
 
-        factory = ManagedCassandraClientFactory(keyspace)
-        reactor.connectTCP(settings.CASS_HOST, settings.CASS_PORT, factory)
-        self.client = CassandraClient(factory)
+        self.factory = ManagedCassandraClientFactory(keyspace)
+        reactor.connectTCP(settings.CASS_HOST, settings.CASS_PORT, self.factory)
+        self.client = CassandraClient(self.factory)
 
 
 class CassandraModel(object):
@@ -66,6 +66,10 @@ class CassandraModel(object):
         to make unit testing without a real cassandra database possible"""
         cls.cass_connection = CassandraConnection(cls.cass_keyspace)
         cls.client = cls.cass_connection.client
+
+    @classmethod
+    def get_cass_factory(cls):
+        return cls.cass_connection.factory
 
     def __init__(self, row_key):
         self.row_key = row_key


### PR DESCRIPTION
Hi Ellie, please could you review this fix to #283 which reworks the ping handler so that it can check homestead-prov's connection to cassandra as well as homer's. I've tested this live as follows:

* Stopped cassandra. Homer and homestead-prov restart periodically. 
* Started casssandra. Homer and homestead-prov start up and stay running. 