### PR TITLE
[Reviewer: RKD] Hide confusing output

### DIFF
--- a/src/metaswitch/crest/tools/stress_provision.sh
+++ b/src/metaswitch/crest/tools/stress_provision.sh
@@ -12,7 +12,9 @@ filename=/tmp/$$.users.csv
 echo sip:$DN@$home_domain,$DN@$home_domain,$home_domain,7kkzTyGW ;
 done > $filename
 
-/usr/share/clearwater/crest/src/metaswitch/crest/tools/bulk_create.py $filename
+echo "Creating $num_users users..."
+
+/usr/share/clearwater/crest/src/metaswitch/crest/tools/bulk_create.py $filename > /dev/null 2>&1
 /tmp/$$.users.create_homestead.sh > /dev/null 2>&1
 
 echo "Created $num_users users"


### PR DESCRIPTION
I ran the new bulk_prov script, and it gave me this output:
```
Generating bulk provisioning scripts for users in /tmp/26656.users.csv...
Generated homestead bulk provisioning scripts
- /tmp/26656.users.create_homestead.sh           - run this script on Homestead
- /tmp/26656.users.create_homestead_cache.casscli - copy this file onto Homestea                                                                             d
- /tmp/26656.users.create_homestead_provisioning.casscli - copy this file onto H                                                                             omestead
Generated homer bulk provisioning scripts
- /tmp/26656.users.create_xdm.sh                 - run this script on Homer
- /tmp/26656.users.create_xdm.cqlsh              - copy this file onto Homer
Created 50000 users
```

This is a bit confusing - I shouldn't be running the scripts mentioned in the output.

This PR hides this output. Tested live.