### PR TITLE
[Reviewer: Ellie] Install up to date virtualenv

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -30,43 +30,49 @@ Pre-requisites
 
 Crest relies on APT packages available from the Project Clearwater repository server. To configure your build environment to install these packages, follow the instructions at [ReadTheDocs](http://clearwater.readthedocs.org/en/latest/Manual_Install.html#configure-the-apt-software-sources).
 
-1. Pip and virtualenv
+1. Pip and build tools
 
     ```
     sudo apt-get install python-pip python-dev python-virtualenv build-essential libffi-dev
     ```
 
-2. Lib-curl
+2. virtualenv
+
+   ```
+   sudo pip install virtualenv
+   ```
+
+3. Lib-curl
 
     ```
     sudo apt-get install libcurl4-openssl-dev
     ```
 
-3. Building Debian packages
+4. Building Debian packages
 
     ```
     sudo apt-get install debhelper devscripts
     ```
 
-4. XML development libraries
+5. XML development libraries
 
     ```
     sudo apt-get install libxml2-dev libxslt-dev
     ```
 
-5. Python static analysis checker
+6. Python static analysis checker
 
    ```
    sudo pip install flake8 mccabe pep8-naming
    ```
 
-6. ZMQ libraries
+7. ZMQ libraries
 
    ```
    sudo apt-get install python-zmq
    ```
 
-7. Bulk provisioning
+8. Bulk provisioning
 
    ```
    sudo apt-get install cassandra=2.0.14 openjdk-7-jdk

--- a/docs/development.md
+++ b/docs/development.md
@@ -33,7 +33,7 @@ Crest relies on APT packages available from the Project Clearwater repository se
 1. Pip and build tools
 
     ```
-    sudo apt-get install python-pip python-dev python-virtualenv build-essential libffi-dev
+    sudo apt-get install python-pip python-dev build-essential libffi-dev
     ```
 
 2. virtualenv (we pin to 13.1.0 so that we have a known working version, but we should be careful that the version used doesn't fall too far behind)

--- a/docs/development.md
+++ b/docs/development.md
@@ -36,10 +36,10 @@ Crest relies on APT packages available from the Project Clearwater repository se
     sudo apt-get install python-pip python-dev python-virtualenv build-essential libffi-dev
     ```
 
-2. virtualenv
+2. virtualenv (we pin to 13.1.0 so that we have a known working version, but we should be careful that the version used doesn't fall too far behind)
 
    ```
-   sudo pip install virtualenv
+   sudo pip install virtualenv==13.1.0
    ```
 
 3. Lib-curl


### PR DESCRIPTION
The apt python-virtualenv package installs virtualenv 1.11.4. This is not up to date enough for our builds.

This instead uses pip to install the latest virtualenv package. At time of testing, this pulled down 15.1.0. The version in use on a number of machines is 13.1.0. 

@eleanor-merry Do you think we should pin to 13.1.0? The builds work with the latest version, but if the install command doesn't specify a version, it will not upgrade to a new version if someone has already installed the apt package.
