### PR TITLE
[No reviewer] Pin to thrift 0.9.3, as it updated to 0.10.0

### DIFF
--- a/setup_crest.py
+++ b/setup_crest.py
@@ -57,7 +57,7 @@ setup(
     packages=find_packages('src', include=['metaswitch', 'metaswitch.crest', 'metaswitch.crest.*']),
     package_dir={'':'src'},
     test_suite='metaswitch.crest.test',
-    install_requires=["pyzmq==16.0.2", "py-bcrypt", "cyclone==1.0", "cql==1.4.0", "lxml==3.6.0", "msgpack-python==0.4.7", "pure-sasl", "prctl", "monotonic==0.6"],
+    install_requires=["pyzmq==16.0.2", "py-bcrypt", "cyclone==1.0", "cql==1.4.0", "lxml==3.6.0", "msgpack-python==0.4.7", "pure-sasl", "prctl", "monotonic==0.6", "thrift==0.9.3"],
     tests_require=["pbr==1.6", "Mock"],
     options={"build": {"build_base": "build-crest"}},
     )


### PR DESCRIPTION
Tested live on EC2, this gets things alive again. Fixes #325 

We should do a proper investigation of what things we depend on, and consider version pinning more. In the process of tracking this down, I also saw that twisted has updated, and in testing that i also had to specifically pin setuptools=24 in setup_crest.py (not sure why, but install failed without this).

However, this PR is just MVP for unblocking everything.
@sebrexmetaswitch this should have been built by the morning, so you should be good to go