### PR TITLE
[Reviewer: Ellie] Better load monitor. In line with cpp monitoring

### DIFF
--- a/src/metaswitch/crest/api/base.py
+++ b/src/metaswitch/crest/api/base.py
@@ -113,8 +113,9 @@ class LeakyBucket:
 
 
 class LoadMonitor:
-    # Number of request processed between each adjustment of the leaky bucket rate
-    ADJUST_PERIOD = 20
+    # Minimum requests processed and time between each adjustment of the leaky bucket rate
+    REQUESTS_BEFORE_ADJUSTMENT = 20
+    SECONDS_BEFORE_ADJUSTMENT = 2
 
     # Adjustment parameters for
     DECREASE_THRESHOLD = 0.0
@@ -135,9 +136,10 @@ class LoadMonitor:
         self.smoothed_variability = target_latency
         self.max_latency = self.smoothed_latency + (self.NUM_DEV * self.smoothed_variability)
         self.bucket = LeakyBucket(max_bucket_size, init_token_rate)
-        self.adjust_count = self.ADJUST_PERIOD
+        self.adjust_count = self.REQUESTS_BEFORE_ADJUSTMENT
         self.min_token_rate = min_token_rate
         self.overloaded = False
+        self.last_adjustment_time = monotonic()
 
     def admit_request(self):
         if self.bucket.get_token():
@@ -166,8 +168,9 @@ class LoadMonitor:
         self.smoothed_variability = (7 * self.smoothed_variability + abs(latency - self.smoothed_latency)) / 8
         self.max_latency = self.smoothed_latency + (self.NUM_DEV * self.smoothed_variability)
         self.adjust_count -= 1
+        seconds_since_last_update = monotonic() - self.last_adjustment_time
 
-        if self.adjust_count <= 0:
+        if (self.adjust_count <= 0) and (seconds_since_last_update >= self.SECONDS_BEFORE_ADJUSTMENT):
             # This algorithm is based on the Welsh and Culler "Adaptive Overload
             # Control for Busy Internet Servers" paper, although based on a smoothed
             # mean latency, rather than the 90th percentile as per the paper.
@@ -177,9 +180,6 @@ class LoadMonitor:
             if (self.accepted + self.rejected) != 0:
                 accepted_percent = 100 * (float(self.accepted) / float(self.accepted + self.rejected))
 
-            self.accepted = 0
-            self.rejected = 0
-            self.adjust_count = self.ADJUST_PERIOD
             err = (self.smoothed_latency - self.target_latency) / self.target_latency
             hss_overloads = penaltycounter.get_hss_penalty_count()
             if ((err > self.DECREASE_THRESHOLD) or (hss_overloads > 0)):
@@ -188,25 +188,45 @@ class LoadMonitor:
                 new_rate = self.bucket.rate / self.DECREASE_FACTOR
                 if new_rate < self.min_token_rate:
                     new_rate = self.min_token_rate
-                _log.info("Accepted %f requests, latency error = %f, HSS overloads = %d, decrease rate %f to %f" %
+                _log.info("Accepted %.2f%% of requests, latency error = %f, HSS overloads = %d, decrease rate %f to %f" %
                                  (accepted_percent, err, hss_overloads, self.bucket.rate, new_rate))
                 self.bucket.update_rate(new_rate)
             elif err < self.INCREASE_THRESHOLD:
-                # latency is sufficiently below the target, so we can increase by an additive
-                # factor - weighted by how far below target we are.
-                new_rate = self.bucket.rate + (-err) * self.bucket.max_size * self.INCREASE_FACTOR
-                _log.info("Accepted %f%% of requests, latency error = %f, increase rate %f to %f" %
-                                (accepted_percent, err, self.bucket.rate, new_rate))
-                self.bucket.update_rate(new_rate)
+                # latency is sufficiently below the target, so increasing the permitted
+                # request rate would be sensible; but first check that we are using a
+                # significant proportion of the current rate - if we're allowing 100
+                # requests/sec, and we get 1 request/sec during a quiet period, we will
+                # handle that well, but it is not sufficient evidence that we can increase the rate.
+                max_permitted_requests = self.bucket.rate * seconds_since_last_update
+
+                # Arbitrary threshold of at least 50% of maximum permitted requests
+                minimum_threshold = max_permitted_requests * 0.5
+
+                if (self.accepted > minimum_threshold):
+                    new_rate = self.bucket.rate + (-err) * self.bucket.max_size * self.INCREASE_FACTOR
+                    _log.info("Accepted %.2f%% of requests, latency error = %f, increase rate %f to %f"
+                              " based on %d accepted requests in last %.2f seconds" %
+                              (accepted_percent, err, self.bucket.rate, new_rate,
+                               self.accepted, seconds_since_last_update))
+                    self.bucket.update_rate(new_rate)
+                else:
+                    _log.info("Only handled %d requests in the last %.2f seconds, rate remains unchanged."
+                              " Minimum threshold for change is %f" %
+                              (self.accepted, seconds_since_last_update, minimum_threshold))
             else:
                 _log.info("Accepted %f%% of requests, latency error = %f, rate %f unchanged" %
                                 (accepted_percent, err, self.bucket.rate))
 
+            self.accepted = 0
+            self.rejected = 0
+            self.adjust_count = self.REQUESTS_BEFORE_ADJUSTMENT
+            self.last_adjustment_time = monotonic()
+
         penaltycounter.reset_hss_penalty_count()
 
 # Create load monitor with target latency of 100ms, maximum bucket size of
-# 20 requests, initial and minimum token rate of 10 per second
-loadmonitor = LoadMonitor(0.1, 20, 10, 10)
+# 100 requests, initial and minimum token rate of 10 per second
+loadmonitor = LoadMonitor(0.1, 100, 100, 10)
 penaltycounter = PenaltyCounter()
 
 # Create the accumulators and counters

--- a/src/metaswitch/crest/api/base.py
+++ b/src/metaswitch/crest/api/base.py
@@ -225,8 +225,8 @@ class LoadMonitor:
         penaltycounter.reset_hss_penalty_count()
 
 # Create load monitor with target latency of 100ms, maximum bucket size of
-# 100 requests, initial and minimum token rate of 10 per second
-loadmonitor = LoadMonitor(0.1, 100, 100, 10)
+# 1000 request tokens, initial token rate of 100/s, and a minimum rate of 10/s
+loadmonitor = LoadMonitor(0.1, 1000, 100, 10)
 penaltycounter = PenaltyCounter()
 
 # Create the accumulators and counters

--- a/src/metaswitch/crest/test/api/base.py
+++ b/src/metaswitch/crest/test/api/base.py
@@ -174,6 +174,16 @@ class TestUnknownApiHandler(unittest.TestCase):
 
 class TestLoadMonitor(unittest.TestCase):
 
+    def setUp(self):
+        # Mock out zmq so we don't fail if we try to report stats during the
+        # test.
+        self.real_zmq = base.zmq
+        base.zmq = MagicMock()
+
+    def tearDown(self):
+        base.zmq = self.real_zmq
+        del self.real_zmq
+
     def test_divide_by_zero(self):
         """
         Test that twice the LoadMonitor's REQUESTS_BEFORE_ADJUSTMENT requests all
@@ -214,16 +224,15 @@ class TestLoadMonitor(unittest.TestCase):
         # Create a load monitor as we do in the main crest base
         load_monitor = base.LoadMonitor(0.1, 100, 100, 10)
 
-        success = True 
         initial_rate = load_monitor.bucket.rate
         # We need this to be a float, so that the sleeps below don't round to 0
         update_period = float(load_monitor.SECONDS_BEFORE_ADJUSTMENT)
 
-        # The number of requests we need to send to go over the threshold is: 
+        # The number of requests we need to send to go over the adjustment threshold is:
         threshold_requests = load_monitor.bucket.rate * load_monitor.SECONDS_BEFORE_ADJUSTMENT
 
-        # To simulate the right load, we will add three sets of half this threshold the time period
-        # and then trigger the update_latency function at the end of it.
+        # To simulate load, we will add three sets of half this threshold over the
+        # time period and then trigger the update_latency function at the end of it.
         for _ in range(3):
             for _ in range(threshold_requests/2):
                 load_monitor.admit_request()
@@ -232,9 +241,9 @@ class TestLoadMonitor(unittest.TestCase):
             sleep(update_period/4)
 
         # Do one last sleep, so that we pass the time threshold
-        sleep(update_period/4 + 0.5)
+        sleep(update_period/4 + 0.1)
 
-        # Do one more request, and then test to see if the rate has increased
+        # Do one more request, and then test that the rate has increased
         load_monitor.admit_request()
         load_monitor.request_complete()
         load_monitor.update_latency(0.08)
@@ -243,12 +252,156 @@ class TestLoadMonitor(unittest.TestCase):
         print("Initial rate {}, final rate {}".format(initial_rate, final_rate))
         self.assertTrue(final_rate > initial_rate)
 
-        # Test if errors > threshold, rate reduced
-        # same, but hss overload
+    def test_rate_decrease_on_err(self):
+        """
+        Test that when we are accepting requests but with a higher than target
+        latency, we decrease the permitted request rate.
+        """
 
-        # Test if accepted > min_thresh, and t > 2, rate increased
-        # Test if accepted > min thresh and t < 2, no change
-        # Test if accepted < min thresh and t > 2, no change
+        # Create a load monitor as we do in the main crest base, and save off initial rate
+        load_monitor = base.LoadMonitor(0.1, 100, 100, 10)
+        initial_rate = load_monitor.bucket.rate
+
+        # We need this to be a float, so that the sleeps below don't round to 0
+        update_period = float(load_monitor.SECONDS_BEFORE_ADJUSTMENT)
+
+        # The number of requests we need to send to go over the adjustment threshold is:
+        threshold_requests = load_monitor.bucket.rate * load_monitor.SECONDS_BEFORE_ADJUSTMENT
+
+        # To simulate load, we will add three sets of half this threshold over the
+        # time period and then trigger the update_latency function at the end of it.
+        # We update with a latency higher than our target to trigger the err threshold.
+        for _ in range(3):
+            for _ in range(threshold_requests/2):
+                load_monitor.admit_request()
+                load_monitor.request_complete()
+                load_monitor.update_latency(0.15)
+            sleep(update_period/4)
+
+        # Do one last sleep, so that we pass the time threshold
+        sleep(update_period/4 + 0.1)
+
+        # Do one more request, and then test that the rate has decreased
+        load_monitor.admit_request()
+        load_monitor.request_complete()
+        load_monitor.update_latency(0.15)
+
+        final_rate = load_monitor.bucket.rate
+        print("Initial rate {}, final rate {}".format(initial_rate, final_rate))
+        self.assertTrue(final_rate < initial_rate)
+
+    # Mock out the penalty counter to return a non-zero penalty count
+    @patch("metaswitch.crest.api.base.PenaltyCounter.get_hss_penalty_count", return_value=1)
+    def test_rate_decrease_on_hss_overload(self, mock_penaltycounter):
+        """
+        Test that when we are accepting requests within target latency, but
+        are getting hss overload responses, we decrease the permitted request rate.
+        """
+
+        # Create a load monitor as we do in the main crest base, and save off initial rate
+        load_monitor = base.LoadMonitor(0.1, 100, 100, 10)
+        initial_rate = load_monitor.bucket.rate
+
+        # We need this to be a float, so that the sleeps below don't round to 0
+        update_period = float(load_monitor.SECONDS_BEFORE_ADJUSTMENT)
+
+        # The number of requests we need to send to go over the adjustment threshold is:
+        threshold_requests = load_monitor.bucket.rate * load_monitor.SECONDS_BEFORE_ADJUSTMENT
+
+        # To simulate load, we will add three sets of half this threshold over the time period
+        # and then trigger the update_latency function at the end of it.
+        # We update with a latency higher than our target to trigger the err threshold.
+        for _ in range(3):
+            for _ in range(threshold_requests/2):
+                load_monitor.admit_request()
+                load_monitor.request_complete()
+                load_monitor.update_latency(0.08)
+            sleep(update_period/4)
+
+        # Do one last sleep, so that we pass the time threshold
+        sleep(update_period/4 + 0.1)
+
+        # Do one more request, and then test that the rate has decreased
+        load_monitor.admit_request()
+        load_monitor.request_complete()
+        load_monitor.update_latency(0.08)
+
+        final_rate = load_monitor.bucket.rate
+        print("Initial rate {}, final rate {}".format(initial_rate, final_rate))
+        self.assertTrue(final_rate < initial_rate)
+
+    def test_rate_no_change_if_time_too_short(self):
+        """
+        Test that when we have accepted more than half the maximum permitted requests
+        but haven't passed the update period, we do not change the permitted request rate.
+        """
+
+        # Create a load monitor as we do in the main crest base
+        load_monitor = base.LoadMonitor(0.1, 100, 100, 10)
+
+        initial_rate = load_monitor.bucket.rate
+        # We need this to be a float, so that the sleeps below don't round to 0
+        update_period = float(load_monitor.SECONDS_BEFORE_ADJUSTMENT)
+
+        # The number of requests we need to send to go over the adjustment threshold is:
+        threshold_requests = load_monitor.bucket.rate * load_monitor.SECONDS_BEFORE_ADJUSTMENT
+
+        # To simulate load, we will add three sets of half this threshold over the time period
+        # and then trigger the update_latency function at the end of it.
+        for _ in range(3):
+            for _ in range(threshold_requests/2):
+                load_monitor.admit_request()
+                load_monitor.request_complete()
+                load_monitor.update_latency(0.08)
+            sleep(update_period/4)
+
+        # We do not sleep here, as we want to remain under the update_period
+        # Do one more request, and then test that the rate remains unchanged
+        load_monitor.admit_request()
+        load_monitor.request_complete()
+        load_monitor.update_latency(0.08)
+
+        final_rate = load_monitor.bucket.rate
+        print("Initial rate {}, final rate {}".format(initial_rate, final_rate))
+        self.assertTrue(final_rate == initial_rate)
+
+    def test_rate_no_change_if_too_few_requests(self):
+        """
+        Test that when we have accepted less than half the maximum permitted requests
+        over the update period, we do not change the permitted request rate.
+        """
+
+        # Create a load monitor as we do in the main crest base
+        load_monitor = base.LoadMonitor(0.1, 100, 100, 10)
+
+        initial_rate = load_monitor.bucket.rate
+        # We need this to be a float, so that the sleeps below don't round to 0
+        update_period = float(load_monitor.SECONDS_BEFORE_ADJUSTMENT)
+
+        # The number of requests we need to send to go over the adjustment threshold is:
+        threshold_requests = load_monitor.bucket.rate * load_monitor.SECONDS_BEFORE_ADJUSTMENT
+
+        # To simulate light load, we will add three sets of one tenth of this
+        # threshold over the time period and then trigger the update_latency
+        # function at the end of it.
+        for _ in range(3):
+            for _ in range(threshold_requests/10):
+                load_monitor.admit_request()
+                load_monitor.request_complete()
+                load_monitor.update_latency(0.08)
+            sleep(update_period/4)
+
+        # Do one last sleep, so that we pass the time threshold
+        sleep(update_period/4 + 0.1)
+
+        # Do one more request, and then test that the rate remains unchanged
+        load_monitor.admit_request()
+        load_monitor.request_complete()
+        load_monitor.update_latency(0.08)
+
+        final_rate = load_monitor.bucket.rate
+        print("Initial rate {}, final rate {}".format(initial_rate, final_rate))
+        self.assertTrue(final_rate == initial_rate)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This came out of investigating #244 . As Chris suggested there, increasing the size of the bucket is the simplest resolution; i've upped it to 100 for now, with an initial rate of 100, but i'd like to discuss what you think actual reasonable values for the token rates etc. would be.

While investigating, i saw that as long as the latency was good, the token rate would increase every 20 requests, with no upper limit, so i've ported over the function already present in https://github.com/Metaswitch/cpp-common/blob/master/src/load_monitor.cpp#L85 to give us a min_threshold of accepted requests relative to the rate for us to qualify for rate increase.

Tested live, by running `while true; do curl -v "http://hs.ajl.cw-ngv.com:8889/private/2345550154%40ajl.cw-ngv.com/associated_public_ids" && curl -v -X POST "http://hs.ajl.cw-ngv.com:8889/irs"; sleep 0.5; done` with various different sleep times to simulate different load. This confirms that it reaches stable states, and doesn't increase forever.
With 0 sleep (i.e. hammering it with lots of requests), we do not now go into overload with the above command. The logs show the following behaviour:
```
18-01-2017 12:38:15.130 UTC INFO base.py:215: Only handled 20 requests in the last 32.08 seconds, rate remains unchanged. Minimum threshold for change is 1603.843692
18-01-2017 12:38:17.134 UTC INFO base.py:210: Accepted 100.00% of requests, latency error = -0.981614, increase rate 100.000000 to 149.080680 based on 159 accepted requests in last 2.00 seconds
18-01-2017 12:38:19.140 UTC INFO base.py:210: Accepted 100.00% of requests, latency error = -0.982391, increase rate 149.080680 to 198.200217 based on 161 accepted requests in last 2.01 seconds
18-01-2017 12:38:21.153 UTC INFO base.py:215: Only handled 161 requests in the last 2.01 seconds, rate remains unchanged. Minimum threshold for change is 199.452985
18-01-2017 12:38:23.165 UTC INFO base.py:215: Only handled 156 requests in the last 2.01 seconds, rate remains unchanged. Minimum threshold for change is 199.339306
18-01-2017 12:38:25.167 UTC INFO base.py:215: Only handled 154 requests in the last 2.00 seconds, rate remains unchanged. Minimum threshold for change is 198.386470
18-01-2017 12:38:27.177 UTC INFO base.py:215: Only handled 158 requests in the last 2.01 seconds, rate remains unchanged. Minimum threshold for change is 199.095796
18-01-2017 12:38:29.188 UTC INFO base.py:215: Only handled 165 requests in the last 2.01 seconds, rate remains unchanged. Minimum threshold for change is 199.293110
18-01-2017 12:38:31.190 UTC INFO base.py:215: Only handled 162 requests in the last 2.00 seconds, rate remains unchanged. Minimum threshold for change is 198.357803
18-01-2017 12:38:33.190 UTC INFO base.py:215: Only handled 156 requests in the last 2.00 seconds, rate remains unchanged. Minimum threshold for change is 198.206667
18-01-2017 12:38:35.192 UTC INFO base.py:215: Only handled 154 requests in the last 2.00 seconds, rate remains unchanged. Minimum threshold for change is 198.299672
```