### PR TITLE
[Reviewer: Graeme] Stop murder circle

### DIFF
--- a/debian/homer.init.d
+++ b/debian/homer.init.d
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # @file homer.init.d
 #
@@ -50,7 +50,7 @@ DESC=homer       # Introduce a short description here
 NAME=homer       # Introduce the short server's name here
 DAEMON=/usr/share/clearwater/crest/env/bin/python # Introduce the server's location here
 DAEMON_ARGS="-m metaswitch.crest.main --worker-processes $(cat /proc/cpuinfo | grep processor | wc -l)"
-DAEMON_DIR=/usr/share/clearwater/homer/
+DAEMON_DIR=/usr/share/clearwater/homer
 PIDFILE=/var/run/$NAME.pid
 SCRIPTNAME=/etc/init.d/$NAME
 
@@ -174,8 +174,14 @@ else
 fi
 if [ -n "$leaked_pids" ] ; then
   for pid in $leaked_pids ; do
-    logger -p daemon.error -t $NAME Found leaked homer $pid \(correct is $(cat $PIDFILE)\) - killing $pid
-    kill -9 $pid
+    # Homer and Homestead-prov run the same daemon, but in different working directories
+    # Make sure this is actually a leaked process by checking the working directory matches
+    # our expectations, and we aren't killing the wrong things
+    working_dir=$(pwdx $pid)
+    if grep $DAEMON_DIR <<< $working_dir ; then
+      logger -p daemon.error -t $NAME Found leaked homer $pid \(correct is $(cat $PIDFILE)\) - killing $pid
+      kill -9 $pid
+    fi
   done
 fi
 


### PR DESCRIPTION
Yeah. So my changes in https://github.com/Metaswitch/crest/pull/331 just meant that they would murder-cycle forever. 
This should have them properly check the working directory of the 'leaked' pids they find, and only kill things that match their DAEMON_DIR.
Tested live, and resolves issue https://github.com/Metaswitch/crest/issues/333 , so i'm pretty sure this is good. Still worth a review though. 

Going to go through the other init file changes i made to make sure there aren't any other possible process deathmatches going on