### PR TITLE
[Reviewer: Seb] Build and install fixes

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,7 @@ Priority: optional
 # clearwater-infrastructure explicitly checks for packages of this name when
 # updating
 Maintainer: Project Clearwater Maintainers <maintainers@projectclearwater.org>
-Build-Depends: debhelper (>= 8.0.0)
+Build-Depends: debhelper (>= 8.0.0), cassandra (= 2.1.15), openjdk-7-jdk
 Standards-Version: 3.9.2
 Homepage: http://projectclearwater.org/
 

--- a/debian/crest.postinst
+++ b/debian/crest.postinst
@@ -52,7 +52,6 @@ set -e
 # the debian-policy package
 
 CREST_DIR=/usr/share/clearwater/crest
-. /etc/clearwater/config
 
 case "$1" in
     configure)

--- a/debian/homestead-prov.postinst
+++ b/debian/homestead-prov.postinst
@@ -53,7 +53,6 @@ set -e
 
 HOMESTEAD_DIR=/usr/share/clearwater/homestead
 CREST_DIR=/usr/share/clearwater/crest
-. /etc/clearwater/config
 
 case "$1" in
     configure)


### PR DESCRIPTION
Two fixes to the way we build and install crest.

One fixes missing build dependencies - we require cassandra and a Java JDK to build the sstable provisioning tool - https://github.com/Metaswitch/crest/tree/dev/src/metaswitch/crest/tools/sstable_provisioning

Secondly, remove a requirement for config to be setup at package installation time.

