### PR TITLE
[Reviewer: EM] Fix up provisioning scripts

### DIFF
--- a/debian/homestead-prov-cassandra.install
+++ b/debian/homestead-prov-cassandra.install
@@ -1,3 +1,4 @@
 homestead-prov-cassandra.root/* /
 src/metaswitch/crest/tools /usr/share/clearwater/crest/src/metaswitch/crest/
 src/metaswitch/crest/tools/sstable_provisioning/* /usr/share/clearwater/crest/tools/sstable_provisioning
+.crest-eggs/* /usr/share/clearwater/crest/.eggs/

--- a/debian/homestead-prov-cassandra.postinst
+++ b/debian/homestead-prov-cassandra.postinst
@@ -56,10 +56,15 @@ set -e
 
 #DEBHELPER#
 
+CREST_DIR=/usr/share/clearwater/crest
+
 case "$1" in
     configure)
         # Restart clearwater-infrastructure in order to trigger the
         # homestead-prov-cassandra script.
+        rm -rf $CREST_DIR/build
+        virtualenv --python=$(which python) $CREST_DIR/env
+        $CREST_DIR/env/bin/easy_install --allow-hosts=None -f $CREST_DIR/.eggs/ $CREST_DIR/.eggs/*.egg
         service clearwater-infrastructure restart
     ;;
 


### PR DESCRIPTION
Installs the crest eggs as part of the homestead-prov-cassandra debian package so that the provisioning scripts will work wherever this package is installed.

Tested that this fixed the issue I saw.