### PR TITLE
[Reviewer: EM] Remove BarringIndication field from provisioning scripts

### DIFF
--- a/src/metaswitch/crest/tools/bulk_create.py
+++ b/src/metaswitch/crest/tools/bulk_create.py
@@ -73,7 +73,7 @@ def write_homestead_scripts(csv_filename, write_plaintext_password):
             # Generate the user-specific data
             hash = utils.md5("%s:%s:%s" % (private_id, realm, password))
 
-            public_identity_xml = "<PublicIdentity><BarringIndication>1</BarringIndication><Identity>%s</Identity></PublicIdentity>" % public_id
+            public_identity_xml = "<PublicIdentity><Identity>%s</Identity></PublicIdentity>" % public_id
             initial_filter_xml = ifcs.generate_ifcs(utils.sip_uri_to_domain(public_id))
             ims_subscription_xml = create_imssubscription_xml(private_id, public_identity_xml, initial_filter_xml)
             irs_uuid = str(uuid.uuid4())

--- a/src/metaswitch/crest/tools/sstable_provisioning/ClearwaterBulkProvisioner.java
+++ b/src/metaswitch/crest/tools/sstable_provisioning/ClearwaterBulkProvisioner.java
@@ -318,7 +318,6 @@ class RangeSubscriberIterator extends BaseSubscriberIterator
     static final String EMPTY_IFC_XML =                "<InitialFilterCriteria/>";
     static final String SERVICE_PROFILE_XML_SUFFIX = "</ServiceProfile>";
     static final String PUBLIC_IDENTITY_XML_PREFIX = "<PublicIdentity>" +
-                                                       "<BarringIndication>1</BarringIndication>" +
                                                        "<Identity>";
     static final String PUBLIC_IDENTITY_XML_SUFFIX =   "</Identity>" +
                                                      "</PublicIdentity>";

--- a/src/metaswitch/crest/tools/sstable_provisioning/prepare_csv.py
+++ b/src/metaswitch/crest/tools/sstable_provisioning/prepare_csv.py
@@ -47,7 +47,7 @@ def standalone():
 
                     # Hash the password and generate the IMSSubscriptionXML.
                     hash = utils.md5("%s:%s:%s" % (private_id, realm, password))
-                    publicidentity_xml = "<PublicIdentity><BarringIndication>1</BarringIndication><Identity>%s</Identity></PublicIdentity>" % public_id
+                    publicidentity_xml = "<PublicIdentity><Identity>%s</Identity></PublicIdentity>" % public_id
                     initial_filter_xml = ifcs.generate_ifcs(utils.sip_uri_to_domain(public_id))
                     ims_subscription_xml = create_imssubscription_xml(private_id, publicidentity_xml, initial_filter_xml)
                     irs_uuid = uuid.uuid4();


### PR DESCRIPTION
Now that we've added support for this field, it breaks registrations since Homestead-prov returns iFCs that have no unbarred URIs.