### PR TITLE
[Reviewer: Seb] IPv6 Support Homestead Provisioning

### DIFF
--- a/src/metaswitch/crest/api/ping.py
+++ b/src/metaswitch/crest/api/ping.py
@@ -53,6 +53,6 @@ class PingHandler(RequestHandler):
             # in a timely fashion. Writing a log would be spammy.
             pass
 
-        _log.debug("Handled ping request succesfully")
+        _log.debug("Handled ping request successfully")
 
         self.finish("OK")

--- a/src/metaswitch/crest/api/ping.py
+++ b/src/metaswitch/crest/api/ping.py
@@ -7,10 +7,12 @@
 # Otherwise no rights are granted except for those provided to you by
 # Metaswitch Networks in a separate written agreement.
 
+import logging
 from cyclone.web import RequestHandler
 from telephus.client import CassandraClient
 from twisted.internet import defer
 
+_log = logging.getLogger("crest.ping")
 
 # This class responds to pings - we use it to confirm that Homer/Homestead-prov
 # are still responsive and functional
@@ -42,6 +44,7 @@ class PingHandler(RequestHandler):
             pass
 
         try:
+            _log.debug("Handling ping request")
             gets = (client.get(key='ping', column_family='ping').addErrback(ping_error)
                     for client in clients)
             yield defer.DeferredList(gets)
@@ -49,5 +52,7 @@ class PingHandler(RequestHandler):
             # We don't care about the result, just whether it returns
             # in a timely fashion. Writing a log would be spammy.
             pass
+
+        _log.debug("Handled ping request succesfully")
 
         self.finish("OK")

--- a/src/metaswitch/homestead_prov/cassandra.py
+++ b/src/metaswitch/homestead_prov/cassandra.py
@@ -8,6 +8,7 @@
 # Metaswitch Networks in a separate written agreement.
 
 import socket
+import logging
 from random import shuffle
 from twisted.internet import defer, reactor
 from metaswitch.crest.api import settings
@@ -15,6 +16,7 @@ from telephus.protocol import ManagedCassandraClientFactory
 from telephus.client import CassandraClient, ConsistencyLevel
 from telephus.cassandra.ttypes import Column, Deletion, NotFoundException, UnavailableException
 
+_log = logging.getLogger("hsprov.cassandra")
 
 class CassandraConnection(object):
     """Simple representation of a connection to a Cassandra keyspace"""
@@ -36,6 +38,9 @@ class CassandraConnection(object):
             address = addresses[0][4][0]
         else:
             address = settings.CASS_HOST
+
+        _log.debug("Cassandra is connecting to %s - for host %s",
+                   address, settings.CASS_HOST)
 
         reactor.connectTCP(address, settings.CASS_PORT, self.factory)
         self.client = CassandraClient(self.factory)

--- a/src/metaswitch/homestead_prov/cassandra.py
+++ b/src/metaswitch/homestead_prov/cassandra.py
@@ -7,6 +7,8 @@
 # Otherwise no rights are granted except for those provided to you by
 # Metaswitch Networks in a separate written agreement.
 
+import socket
+from random import shuffle
 from twisted.internet import defer, reactor
 from metaswitch.crest.api import settings
 from telephus.protocol import ManagedCassandraClientFactory
@@ -20,7 +22,22 @@ class CassandraConnection(object):
         self._keyspace = keyspace
 
         self.factory = ManagedCassandraClientFactory(keyspace)
-        reactor.connectTCP(settings.CASS_HOST, settings.CASS_PORT, self.factory)
+        addresses = socket.getaddrinfo(settings.CASS_HOST, settings.CASS_PORT)
+
+        # If we are using IPv6, we need to provide an IPv6 address directly
+        # to twisted, as it doesn't support IPv6.
+
+        # addresses is a list of 5 tuple:
+        # (family, socktype, proto, cannonname, sockaddr)
+        shuffle(addresses)
+        if len(addresses) > 1 and addresses[0][0] == socket.AF_INET6:
+            # sockaddr is a 4 tuple:
+            # (address, port, flow, scope)
+            address = addresses[0][4][0]
+        else:
+            address = settings.CASS_HOST
+
+        reactor.connectTCP(address, settings.CASS_PORT, self.factory)
         self.client = CassandraClient(self.factory)
 
 


### PR DESCRIPTION
Seb,

This adds IPv6 support to Homestead Prov.

It's fairly simple, and I've tested both on a VMWare deployment using IPv6 and a Chef deployment using IPv4.

I've also added some useful logging - debug only, so disabled by default, so shouldn't be a problem.

(There's a slightly awkward land mine that the debug log line saying how we are connecting to Cassandra is not emitted even when debug logging is enabled because we don't enable logging until after we've connected to Cassandra...)