### PR TITLE
[Reviewer: Seb] Fix monit file deletion

### DIFF
--- a/debian/homestead-prov.prerm
+++ b/debian/homestead-prov.prerm
@@ -30,7 +30,7 @@ HOMESTEAD_DIR=/usr/share/clearwater/homestead
 case "$1" in
     remove|upgrade|deconfigure)
         # Stop monitoring ourselves
-        for f in $HOMESTEAD_DIR/templates/*.monit; do rm -f /etc/monit/conf.d/`basename $f`; done
+        rm -f /etc/monit/conf.d/homestead-prov.monit
         reload clearwater-monit &> /dev/null || true
 
         # Disable the homestead-prov nginx site


### PR DESCRIPTION
Currently removing homestead-prov erroneously deletes all of the monit files. This fixes that to just remove the one we want to remove.