### PR TITLE
[Reviewer: Seb] Resolve crest build failure with updated IDNA

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,9 @@ $(ENV_DIR)/bin/python: setup_crest.py setup_homer.py setup_homestead_prov.py com
 	$(ENV_DIR)/bin/easy_install distribute
 
 ${ENV_DIR}/.eggs_installed : $(ENV_DIR)/bin/python $(shell find src/metaswitch -type f -not -name "*.pyc") $(shell find common/metaswitch -type f -not -name "*.pyc")
+	# Get rid of any old egg files
+	rm -rf .crest-eggs .homer-eggs .homestead_prov-eggs
+
 	# Generate .egg files for crest, homer, homestead_prov
 	${ENV_DIR}/bin/python setup_crest.py bdist_egg -d .crest-eggs
 	${ENV_DIR}/bin/python setup_homer.py bdist_egg -d .homer-eggs

--- a/debian/.gitignore
+++ b/debian/.gitignore
@@ -1,6 +1,7 @@
 *.debhelper.log
 *.debhelper
 *.substvars
+/copyright
 /changelog
 /files
 /crest/

--- a/setup_crest.py
+++ b/setup_crest.py
@@ -40,7 +40,6 @@ setup(
         "cql==1.4.0",
         "cyclone==1.0",
         "enum34==1.1.6",
-        "idna==2.5",
         "incremental==17.5.0",
         "ipaddress==1.0.18",
         "lxml==3.6.0",
@@ -54,9 +53,12 @@ setup(
         "Twisted==17.1.0",
         "zope.interface==4.4.1",
         # easy_install processes dependencies in reverse order
-        # We need to install cryptography last so that pyOpenSSL
-        # doesn't install a different version later.
-        "cryptography==1.9"],
+        # We need to install cryptography before pyOpenSSL, so that
+        # we doesn't install a different version prior to installing crypto.
+        "cryptography==1.9",
+        # We need to install idna 2.5 before installing cryptography for the
+        # same reason.
+        "idna==2.5"],
      tests_require=[
          "funcsigs==1.0.2",
          "Mock==2.0.0",


### PR DESCRIPTION
Follow on from https://github.com/Metaswitch/crest/pull/353, but this time https://pypi.python.org/pypi/idna has been updated.

As previously discussed, this isn't the correct fix due to how fragile it is.