### PR TITLE
[Reviewer: Seb] Install metaswitch-common dependencies prior to crest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ ${ENV_DIR}/.eggs_installed : $(ENV_DIR)/bin/python $(shell find src/metaswitch -
 	cd telephus && python setup.py bdist_egg -d ../.crest-eggs
 
 	# Download the egg files crest depends upon
-	${ENV_DIR}/bin/easy_install -zmaxd .crest-eggs/ .crest-eggs/*.egg
+	${ENV_DIR}/bin/easy_install -zmaxd .crest-eggs/ .crest-eggs/metaswitchcommon-*.egg .crest-eggs/telephus-*.egg .crest-eggs/crest-*.egg
 
 	# Install the downloaded egg files (this should match the postinst)
 	${ENV_DIR}/bin/easy_install --allow-hosts=None -f .crest-eggs/ .crest-eggs/*.egg

--- a/setup_crest.py
+++ b/setup_crest.py
@@ -58,7 +58,10 @@ setup(
         "cryptography==1.9",
         # We need to install idna 2.5 before installing cryptography for the
         # same reason.
-        "idna==2.5"],
+        "idna==2.5",
+        # metaswitchcommon installs pycparser which cryptography depends on,
+        # so we need to install that first.
+        "metaswitchcommon==0.1"],
      tests_require=[
          "funcsigs==1.0.2",
          "Mock==2.0.0",


### PR DESCRIPTION
Seb,

This all gets worse.

pycparser (used by python-common) is also used by cryptography.

When you run `${ENV_DIR}/bin/easy_install -zmaxd .crest-eggs/ .crest-eggs/*.egg` it installs the eggs in alphabetical order. Thus it picks up crest -> cryptography -> pycparser first, and then common -> pycparser second. The later is pinned to 2.7, but crytography doesn't pin pycparser.

Oddly the install works in the Debian build, but fails in the Debian install - which shouldn't happen.

This fixes it so we install the dependencies for python-common first, and then the dependencies for crest.