### PR TITLE
[Reviewer: Krista] Get return code from cassandra schemas

### DIFF
--- a/homer-cassandra.root/usr/share/clearwater/cassandra-schemas/homer.sh
+++ b/homer-cassandra.root/usr/share/clearwater/cassandra-schemas/homer.sh
@@ -39,3 +39,5 @@ then
              WITH COMPACT STORAGE AND read_repair_chance = 1.0;"
   rc=$?
 fi
+
+exit $rc

--- a/homer-cassandra.root/usr/share/clearwater/cassandra-schemas/homer.sh
+++ b/homer-cassandra.root/usr/share/clearwater/cassandra-schemas/homer.sh
@@ -2,37 +2,40 @@
 
 cassandra_hostname="127.0.0.1"
 
+. /etc/clearwater/config
+
 . /usr/share/clearwater/cassandra_schema_utils.sh
 
 quit_if_no_cassandra
 
-echo "Adding Cassandra schemas..."
+echo "Adding/updating Cassandra schemas..."
+
+count=0
+/usr/share/clearwater/bin/poll_cassandra.sh --no-grace-period > /dev/null 2>&1
+
+while [ $? -ne 0 ]; do
+  ((count++))
+  if [ $count -gt 120 ]; then
+    echo "Cassandra isn't responsive, unable to add/update schemas yet"
+    exit 1
+  fi
+
+  sleep 1
+  /usr/share/clearwater/bin/poll_cassandra.sh --no-grace-period > /dev/null 2>&1
+done
 
 CQLSH="/usr/share/clearwater/bin/run-in-signaling-namespace cqlsh"
 
-if [[ ! -e /var/lib/cassandra/data/homer ]] || \
+rc=0
+
+if [[ ! -e /var/lib/cassandra/data/homestead_provisioning ]] || \
    [[ $cassandra_hostname != "127.0.0.1" ]];
 then
-  count=0
-  /usr/share/clearwater/bin/poll_cassandra.sh --no-grace-period > /dev/null 2>&1
-
-  while [ $? -ne 0 ]; do
-    ((count++))
-    if [ $count -gt 120 ]; then
-      echo "Cassandra isn't responsive, unable to add schemas yet"
-      exit 1
-    fi
-
-    sleep 1
-    /usr/share/clearwater/bin/poll_cassandra.sh --no-grace-period > /dev/null 2>&1
-  done
-
-  replication_str="{'class': 'SimpleStrategy', 'replication_factor': 2}"
-
   # replication_str is set up by
   # /usr/share/clearwater/cassandra-schemas/replication_string.sh
-  echo "CREATE KEYSPACE IF NOT EXISTS homer WITH REPLICATION = $replication_str;
-        USE homer;
-        CREATE TABLE IF NOT EXISTS simservs (user text PRIMARY KEY, value text)
-        WITH COMPACT STORAGE AND read_repair_chance = 1.0;" | $CQLSH
+  $CQLSH -e "CREATE KEYSPACE IF NOT EXISTS homer WITH REPLICATION = $replication_str;
+             USE homer;
+             CREATE TABLE IF NOT EXISTS simservs (user text PRIMARY KEY, value text)
+             WITH COMPACT STORAGE AND read_repair_chance = 1.0;"
+  rc=$?
 fi

--- a/homestead-prov-cassandra.root/usr/share/clearwater/cassandra-schemas/homestead_provisioning.sh
+++ b/homestead-prov-cassandra.root/usr/share/clearwater/cassandra-schemas/homestead_provisioning.sh
@@ -26,16 +26,21 @@ done
 
 CQLSH="/usr/share/clearwater/bin/run-in-signaling-namespace cqlsh"
 
+rc=0
+
 if [[ ! -e /var/lib/cassandra/data/homestead_provisioning ]] || \
    [[ $cassandra_hostname != "127.0.0.1" ]];
 then
   # replication_str is set up by
   # /usr/share/clearwater/cassandra-schemas/replication_string.sh
-  echo "CREATE KEYSPACE IF NOT EXISTS homestead_provisioning WITH REPLICATION = $replication_str;
-USE homestead_provisioning;
-CREATE TABLE IF NOT EXISTS implicit_registration_sets (id uuid PRIMARY KEY, dummy text) WITH COMPACT STORAGE AND read_repair_chance = 1.0;
-CREATE TABLE IF NOT EXISTS service_profiles (id uuid PRIMARY KEY, irs text, initialfiltercriteria text) WITH COMPACT STORAGE AND read_repair_chance = 1.0;
-CREATE TABLE IF NOT EXISTS public (public_id text PRIMARY KEY, publicidentity text, service_profile text) WITH COMPACT STORAGE AND read_repair_chance = 1.0;
-CREATE TABLE IF NOT EXISTS private (private_id text PRIMARY KEY, digest_ha1 text, realm text, plaintext_password text)
-WITH COMPACT STORAGE AND read_repair_chance = 1.0;" | $CQLSH
+  $CQLSH -e "CREATE KEYSPACE IF NOT EXISTS homestead_provisioning WITH REPLICATION = $replication_str;
+             USE homestead_provisioning;
+             CREATE TABLE IF NOT EXISTS implicit_registration_sets (id uuid PRIMARY KEY, dummy text) WITH COMPACT STORAGE AND read_repair_chance = 1.0;
+             CREATE TABLE IF NOT EXISTS service_profiles (id uuid PRIMARY KEY, irs text, initialfiltercriteria text) WITH COMPACT STORAGE AND read_repair_chance = 1.0;
+             CREATE TABLE IF NOT EXISTS public (public_id text PRIMARY KEY, publicidentity text, service_profile text) WITH COMPACT STORAGE AND read_repair_chance = 1.0;
+             CREATE TABLE IF NOT EXISTS private (private_id text PRIMARY KEY, digest_ha1 text, realm text, plaintext_password text)
+             WITH COMPACT STORAGE AND read_repair_chance = 1.0;"
+  rc=$?
 fi
+
+exit $rc

--- a/homestead-prov-cassandra.root/usr/share/clearwater/cassandra-schemas/homestead_provisioning.sh
+++ b/homestead-prov-cassandra.root/usr/share/clearwater/cassandra-schemas/homestead_provisioning.sh
@@ -38,8 +38,7 @@ then
              CREATE TABLE IF NOT EXISTS implicit_registration_sets (id uuid PRIMARY KEY, dummy text) WITH COMPACT STORAGE AND read_repair_chance = 1.0;
              CREATE TABLE IF NOT EXISTS service_profiles (id uuid PRIMARY KEY, irs text, initialfiltercriteria text) WITH COMPACT STORAGE AND read_repair_chance = 1.0;
              CREATE TABLE IF NOT EXISTS public (public_id text PRIMARY KEY, publicidentity text, service_profile text) WITH COMPACT STORAGE AND read_repair_chance = 1.0;
-             CREATE TABLE IF NOT EXISTS private (private_id text PRIMARY KEY, digest_ha1 text, realm text, plaintext_password text)
-             WITH COMPACT STORAGE AND read_repair_chance = 1.0;"
+             CREATE TABLE IF NOT EXISTS private (private_id text PRIMARY KEY, digest_ha1 text, realm text, plaintext_password text) WITH COMPACT STORAGE AND read_repair_chance = 1.0;"
   rc=$?
 fi
 


### PR DESCRIPTION
This adds a return code to adding the schemas so we can retry if it fails. It also moves the Homer schema script to have the same format as the homestead-prov schema script.

Tested live.