### PR TITLE
[Reviewer: Seb] Correctly ignore egg files in analysis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ ${ENV_DIR}/.eggs_installed : $(ENV_DIR)/bin/python $(shell find src/metaswitch -
 	# Touch the sentinel file
 	touch $@
 
-BANDIT_EXCLUDE_LIST = .eggs,_env,telephus,debian,common,build-crest,build-homer,build-homestead_prov,src/metaswitch/crest/test,src/metaswitch/homer/test
+BANDIT_EXCLUDE_LIST = .crest-eggs,.homer-eggs,.homestead_prov-eggs,_env,telephus,debian,common,build-crest,build-homer,build-homestead_prov,src/metaswitch/crest/test,src/metaswitch/homer/test
 include build-infra/cw-deb.mk
 include build-infra/python.mk
 include mk/bulk-provision.mk


### PR DESCRIPTION
Seb,

Most of our Python based repos store their eggs by default in a `.eggs` directory.

Crest doesn't, as it has three packages - so it has `.crest-eggs`, `.homer-eggs`, `.homestead_prov-eggs`. The Bandit exclusion list incorrectly excludes `.eggs`.

This only causes a problem if you build the Debian with `make deb` prior to running `make analysis` and without running `make clean` in between.

I've tested by running `make deb` and then `make analysis` and this passes correctly.