### PR TITLE
[Reviewer: Adam] Add scripts to enable Cassandra for Homer and Homestead Prov

### DIFF
--- a/homer-cassandra.root/usr/share/clearwater/cassandra/users/homer
+++ b/homer-cassandra.root/usr/share/clearwater/cassandra/users/homer
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# @file homer Enable Cassandra for Homer
+#
+# Copyright (C) Metaswitch Networks 2017
+# If license terms are provided to you in a COPYING file in the root directory
+# of the source code repository by which you are accessing this code, then
+# the license outlined in that COPYING file applies to your use.
+# Otherwise no rights are granted except for those provided to you by
+# Metaswitch Networks in a separate written agreement.
+
+if [ -n "$xdms_hostname" ]; then
+  USE_CASSANDRA="Y"
+fi

--- a/homestead-prov-cassandra.root/usr/share/clearwater/cassandra/users/homestead-prov
+++ b/homestead-prov-cassandra.root/usr/share/clearwater/cassandra/users/homestead-prov
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# @file homestead-prov Enable Cassandra for Homestead Prov
+#
+# Copyright (C) Metaswitch Networks 2017
+# If license terms are provided to you in a COPYING file in the root directory
+# of the source code repository by which you are accessing this code, then
+# the license outlined in that COPYING file applies to your use.
+# Otherwise no rights are granted except for those provided to you by
+# Metaswitch Networks in a separate written agreement.
+
+if [ -n "$hs_provisioning_hostname" ]; then
+  USE_CASSANDRA="Y"
+fi


### PR DESCRIPTION
This is the co-requisite change to use the common infrastructure to enable Cassandra as per https://github.com/Metaswitch/clearwater-infrastructure/pull/486