### PR TITLE
[No reviewer] Upgrade pip

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,10 @@ ${ENV_DIR}/.wheels_installed : $(ENV_DIR)/bin/python common/requirements.txt cre
 
 	rm -rf .crest-wheelhouse .homer-wheelhouse .homestead_prov-wheelhouse
 
+	# Ensure we have an up to date version of pip with wheel support
+	${PIP} install --upgrade pip==9.0.1
+	${PIP} install wheel
+
 	# Get crest's dependencies
 	cd common && REQUIREMENTS=../crest-requirements.txt WHEELHOUSE=../.crest-wheelhouse make build_common_wheel
 	cd telephus && ${PYTHON} setup.py bdist_wheel -d ../.crest-wheelhouse


### PR DESCRIPTION
Ensure we have an up to date version of pip with wheel support to avoid:

```
usage: setup.py [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
   or: setup.py --help [cmd1 cmd2 ...]
   or: setup.py --help-commands
   or: setup.py cmd --help

error: invalid command 'bdist_wheel'
```