### PR TITLE
[Reviewer: EM] Set consistency level of reads and writes to quorum

### DIFF
--- a/src/metaswitch/homestead_prov/cassandra.py
+++ b/src/metaswitch/homestead_prov/cassandra.py
@@ -157,7 +157,8 @@ class CassandraModel(object):
                                        column_family=self.cass_table,
                                        mapping=mapping,
                                        ttl=ttl,
-                                       timestamp=timestamp)
+                                       timestamp=timestamp,
+                                       consistency=ConsistencyLevel.QUORUM)
 
     @classmethod
     @defer.inlineCallbacks
@@ -167,14 +168,16 @@ class CassandraModel(object):
         row = map(lambda x: Column(x, mapping[x], timestamp, ttl), mapping)
         row.append(Column(cls.EXISTS_COLUMN, "", timestamp, ttl))
         mutmap = {key: {cls.cass_table: row} for key in keys}
-        yield cls.client.batch_mutate(mutmap)
+        yield cls.client.batch_mutate(mutmap,
+                                      consistency=ConsistencyLevel.QUORUM)
 
     @defer.inlineCallbacks
     def delete_row(self, timestamp=None):
         """Delete this entire row"""
         yield self.client.remove(key=self.row_key,
                                  column_family=self.cass_table,
-                                 timestamp=timestamp)
+                                 timestamp=timestamp,
+                                 consistency=ConsistencyLevel.QUORUM)
 
     @classmethod
     @defer.inlineCallbacks
@@ -183,7 +186,8 @@ class CassandraModel(object):
         mutmap = {}
         row = [Deletion(timestamp)]
         mutmap = {key: {cls.cass_table: row} for key in keys}
-        yield cls.client.batch_mutate(mutmap)
+        yield cls.client.batch_mutate(mutmap,
+                                      consistency=ConsistencyLevel.QUORUM)
 
     @defer.inlineCallbacks
     def delete_column(self, column_name, timestamp=None):
@@ -191,7 +195,8 @@ class CassandraModel(object):
         yield self.client.remove(key=self.row_key,
                                  column_family=self.cass_table,
                                  column=column_name,
-                                 timestamp=timestamp)
+                                 timestamp=timestamp,
+                                 consistency=ConsistencyLevel.QUORUM)
 
     @classmethod
     @defer.inlineCallbacks

--- a/src/metaswitch/homestead_prov/provisioning/models.py
+++ b/src/metaswitch/homestead_prov/provisioning/models.py
@@ -14,6 +14,7 @@ import logging
 
 from twisted.internet import defer
 from telephus.cassandra.ttypes import NotFoundException
+from telephus.client import ConsistencyLevel
 from metaswitch.crest.api.exceptions import IRSNoSIPURI
 
 from .. import config
@@ -392,7 +393,8 @@ class PublicID(ProvisioningModel):
                                                     start=start,
                                                     finish=finish,
                                                     use_tokens=True,
-                                                    count=10000000)
+                                                    count=10000000,
+                                                    consistency=ConsistencyLevel.QUORUM)
         keys = [x.key for x in values if len(x.columns) > 0]
         public_ids = [PublicID(x) for x in keys]
         _log.info("Queried tokens {} to {} - received {} results".format(start, finish, len(public_ids)))

--- a/src/metaswitch/homestead_prov/test/cache/cache.py
+++ b/src/metaswitch/homestead_prov/test/cache/cache.py
@@ -14,6 +14,7 @@ import unittest
 
 from twisted.internet import defer
 from telephus.cassandra.ttypes import Column, Deletion, NotFoundException
+from telephus.client import ConsistencyLevel
 
 from metaswitch.homestead_prov import authtypes
 from metaswitch.homestead_prov.cache.cache import Cache
@@ -71,7 +72,8 @@ class TestCache(unittest.TestCase):
                                     "digest_realm": "realm",
                                     "digest_qop": "qop"}),
             ttl=self.ttl,
-            timestamp=self.timestamp)
+            timestamp=self.timestamp,
+            consistency=ConsistencyLevel.QUORUM)
         batch_insert.callback(None)
         self.assertEquals(res.value(), None)
 
@@ -89,7 +91,8 @@ class TestCache(unittest.TestCase):
                                              column_family="impi",
                                              mapping=DictContaining({"public_id_kermit": ""}),
                                              ttl=self.ttl,
-                                             timestamp=self.timestamp)
+                                             timestamp=self.timestamp,
+                                             consistency=ConsistencyLevel.QUORUM)
         batch_insert.callback(None)
         self.assertEquals(res.value(), None)
 
@@ -130,7 +133,8 @@ class TestCache(unittest.TestCase):
                                         column_family="impu",
                                         mapping=DictContaining({"ims_subscription_xml": "xml", "primary_ccf": "ccf"}),
                                         ttl=self.ttl,
-                                        timestamp=self.timestamp)
+                                        timestamp=self.timestamp,
+                                        consistency=ConsistencyLevel.QUORUM)
         batch_insert.callback(None)
         self.assertEquals(res.value(), None)
 
@@ -143,7 +147,7 @@ class TestCache(unittest.TestCase):
                                                            timestamp=self.timestamp))
         row = {"impu": [Column("ims_subscription_xml", "xml", self.timestamp, self.ttl),
                         Column("_exists", "", self.timestamp, self.ttl)]}
-        self.cass_client.batch_mutate.assert_called_once_with({"pub1": row, "pub2": row})
+        self.cass_client.batch_mutate.assert_called_once_with({"pub1": row, "pub2": row}, consistency=ConsistencyLevel.QUORUM)
         batch_mutate.callback(None)
         self.assertEquals(res.value(), None)
 
@@ -242,7 +246,7 @@ class TestCache(unittest.TestCase):
         self.cass_client.batch_mutate.return_value = batch_mutate = defer.Deferred()
         res = Result(self.cache.delete_multi_private_ids(["priv1", "priv2"], self.timestamp))
         row = {"impi": [Deletion(self.timestamp)]}
-        self.cass_client.batch_mutate.assert_called_once_with({"priv1": row, "priv2": row})
+        self.cass_client.batch_mutate.assert_called_once_with({"priv1": row, "priv2": row}, consistency=ConsistencyLevel.QUORUM)
         batch_mutate.callback(None)
         self.assertEquals(res.value(), None)
 
@@ -251,6 +255,6 @@ class TestCache(unittest.TestCase):
         self.cass_client.batch_mutate.return_value = batch_mutate = defer.Deferred()
         res = Result(self.cache.delete_multi_public_ids(["pub1", "pub2"], self.timestamp))
         row = {"impu": [Deletion(self.timestamp)]}
-        self.cass_client.batch_mutate.assert_called_once_with({"pub1": row, "pub2": row})
+        self.cass_client.batch_mutate.assert_called_once_with({"pub1": row, "pub2": row}, consistency=ConsistencyLevel.QUORUM)
         batch_mutate.callback(None)
         self.assertEquals(res.value(), None)


### PR DESCRIPTION
Sets the consistency level of reads and writes to Cassandra to quorum. This fixes the issue where we could successfully write to Cassandra and then fail to read back the data immediately afterwards.